### PR TITLE
patch: 2.2.5 - improved-version-bumping

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,38 +1,38 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
-	"vcs": {
-		"enabled": true,
-		"clientKind": "git",
-		"useIgnoreFile": true
-	},
-	"files": {
-		"ignoreUnknown": false
-	},
-	"formatter": {
-		"enabled": true,
-		"indentStyle": "tab",
-		"indentWidth": 2
-	},
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"recommended": true
-		}
-	},
-	"javascript": {
-		"formatter": {
-			"quoteStyle": "double",
-			"lineWidth": 200,
-			"trailingCommas": "none",
-			"semicolons": "asNeeded"
-		}
-	},
-	"assist": {
-		"enabled": true,
-		"actions": {
-			"source": {
-				"organizeImports": "on"
-			}
-		}
-	}
+  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "lineWidth": 200,
+      "trailingCommas": "none",
+      "semicolons": "asNeeded"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@vestfoldfylke/vfk-cli",
-	"version": "2.2.4",
+	"version": "2.2.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@vestfoldfylke/vfk-cli",
-			"version": "2.2.4",
+			"version": "2.2.5",
 			"license": "MIT",
 			"dependencies": {
 				"semver": "^7.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vestfoldfylke/vfk-cli",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "A command line interface for our pleasure",
   "main": "dist/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,54 +1,54 @@
 {
-	"name": "@vestfoldfylke/vfk-cli",
-	"version": "2.2.4",
-	"description": "A command line interface for our pleasure",
-	"main": "dist/index.js",
-	"type": "module",
-	"files": [
-		"dist",
-		"package.json"
-	],
-	"scripts": {
-		"build": "tsc",
-		"lint": "npx @biomejs/biome check",
-		"lint:fix": "npx @biomejs/biome check --write",
-		"test": "tsc --noEmit && biome check && node --import tsx --test src/tests/**/*.test.ts",
-		"test:node": "node --test"
-	},
-	"bin": {
-		"vfk": "./dist/index.js"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/vestfoldfylke/vfk-cli.git"
-	},
-	"keywords": [
-		"pleasure"
-	],
-	"author": {
-		"name": "Jørgen Thorsnes",
-		"url": "https://github.com/jorgtho"
-	},
-	"contributors": [
-		{
-			"name": "Rune Moskvil Lyngås",
-			"url": "https://github.com/runely"
-		}
-	],
-	"license": "MIT",
-	"bugs": {
-		"url": "https://github.com/vestfoldfylke/vfk-cli/issues"
-	},
-	"homepage": "https://github.com/vestfoldfylke/vfk-cli#readme",
-	"dependencies": {
-		"semver": "^7.7.4",
-		"yocto-spinner": "^1.1.0"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "2.4.12",
-		"@types/node": "^25.6.0",
-		"@types/semver": "^7.7.1",
-		"tsx": "^4.21.0",
-		"typescript": "^6.0.3"
-	}
+  "name": "@vestfoldfylke/vfk-cli",
+  "version": "2.2.4",
+  "description": "A command line interface for our pleasure",
+  "main": "dist/index.js",
+  "type": "module",
+  "files": [
+    "dist",
+    "package.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "lint": "npx @biomejs/biome check",
+    "lint:fix": "npx @biomejs/biome check --write",
+    "test": "tsc --noEmit && biome check && node --import tsx --test src/tests/**/*.test.ts",
+    "test:node": "node --test"
+  },
+  "bin": {
+    "vfk": "./dist/index.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vestfoldfylke/vfk-cli.git"
+  },
+  "keywords": [
+    "pleasure"
+  ],
+  "author": {
+    "name": "Jørgen Thorsnes",
+    "url": "https://github.com/jorgtho"
+  },
+  "contributors": [
+    {
+      "name": "Rune Moskvil Lyngås",
+      "url": "https://github.com/runely"
+    }
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/vestfoldfylke/vfk-cli/issues"
+  },
+  "homepage": "https://github.com/vestfoldfylke/vfk-cli#readme",
+  "dependencies": {
+    "semver": "^7.7.4",
+    "yocto-spinner": "^1.1.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.4.12",
+    "@types/node": "^25.6.0",
+    "@types/semver": "^7.7.1",
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.3"
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,25 +23,25 @@ const selectedTool: Tool = (process.argv[2] as Tool) || ""
 const args: string[] = process.argv.slice(3)
 
 switch (selectedTool) {
-	case "--version":
-	case "-v":
-		console.log(pkg.version)
-		break
-	case "pr":
-		pr(...args)
-		break
-	case "release":
-		release(...args)
-		break
-	case "nilsrelease":
-		nilsrelease(...args)
-		break
-	case "help":
-		console.log(usage)
-		break
-	case "":
-		console.log(usage)
-		break
-	default:
-		throw new Error("SPECIFIED TOOL NOT FOUND")
+  case "--version":
+  case "-v":
+    console.log(pkg.version)
+    break
+  case "pr":
+    pr(...args)
+    break
+  case "release":
+    release(...args)
+    break
+  case "nilsrelease":
+    nilsrelease(...args)
+    break
+  case "help":
+    console.log(usage)
+    break
+  case "":
+    console.log(usage)
+    break
+  default:
+    throw new Error("SPECIFIED TOOL NOT FOUND")
 }

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -3,120 +3,120 @@ import type { GitCommitType, GitLogCommit, RepoInfo, SortedCommits } from "../ty
 import { getLatestSemverTag } from "./semver.js"
 
 type CommitsBehindAhead = {
-	behind: number
-	ahead: number
+  behind: number
+  ahead: number
 }
 
 const runGitCommand = (command: string): string => {
-	if (!command.startsWith("git ")) {
-		throw new Error("Command must be string and only git commands are allowed")
-	}
+  if (!command.startsWith("git ")) {
+    throw new Error("Command must be string and only git commands are allowed")
+  }
 
-	try {
-		const res = execSync(command)
-		return res.toString().trim()
-	} catch (err) {
-		if (err instanceof Error && err.message.includes("Not a git repository")) {
-			throw new Error("Directory is not a Git repository")
-		}
-		throw err
-	}
+  try {
+    const res = execSync(command)
+    return res.toString().trim()
+  } catch (err) {
+    if (err instanceof Error && err.message.includes("Not a git repository")) {
+      throw new Error("Directory is not a Git repository")
+    }
+    throw err
+  }
 }
 
 const getGithubUsername = (): string | undefined => {
-	try {
-		return runGitCommand("git config --get github.user") ?? runGitCommand("git config --global --get github.user") ?? undefined
-	} catch {
-		return undefined
-	}
+  try {
+    return runGitCommand("git config --get github.user") ?? runGitCommand("git config --global --get github.user") ?? undefined
+  } catch {
+    return undefined
+  }
 }
 
 export const getDefaultBranch = (): string => {
-	return runGitCommand("git rev-parse --abbrev-ref origin/HEAD").replace("origin/", "")
+  return runGitCommand("git rev-parse --abbrev-ref origin/HEAD").replace("origin/", "")
 }
 
 export const getCurrentBranch = (): string => {
-	return runGitCommand("git rev-parse --abbrev-ref HEAD")
+  return runGitCommand("git rev-parse --abbrev-ref HEAD")
 }
 
 export const fetchChangesAndTags = (): string => {
-	return runGitCommand("git fetch --all --tags --quiet")
+  return runGitCommand("git fetch --all --tags --quiet")
 }
 
 export const isRepoClean = (): boolean => {
-	const status: string = runGitCommand("git status")
-	return status.includes("Your branch is up to date with ") && status.includes("nothing to commit, working tree clean")
+  const status: string = runGitCommand("git status")
+  return status.includes("Your branch is up to date with ") && status.includes("nothing to commit, working tree clean")
 }
 
 export const getCommitsBehindAndAheadDefaultBranch = (): CommitsBehindAhead => {
-	const defaultBranch: string = getDefaultBranch()
-	const diff: string = runGitCommand(`git rev-list --left-right --count origin/${defaultBranch}...HEAD`)
-	const [behind, ahead] = diff.split("\t")
-	if (!behind || !ahead) {
-		throw new Error("Could not determine commit difference between current branch and default branch")
-	}
-	return { behind: parseInt(behind, 10), ahead: parseInt(ahead, 10) }
+  const defaultBranch: string = getDefaultBranch()
+  const diff: string = runGitCommand(`git rev-list --left-right --count origin/${defaultBranch}...HEAD`)
+  const [behind, ahead] = diff.split("\t")
+  if (!behind || !ahead) {
+    throw new Error("Could not determine commit difference between current branch and default branch")
+  }
+  return { behind: parseInt(behind, 10), ahead: parseInt(ahead, 10) }
 }
 
 export const getLatestReleaseTag = (): string | null => {
-	const tags: string[] = runGitCommand("git tag").split("\n")
-	return getLatestSemverTag(tags)
+  const tags: string[] = runGitCommand("git tag").split("\n")
+  return getLatestSemverTag(tags)
 }
 
 export const repoIsReadyForPullRequest = (repoInfo: RepoInfo): void => {
-	if (repoInfo.currentBranch === repoInfo.defaultBranch) {
-		throw new Error("You are currently on the default branch. Please switch to a feature branch to create a PR.")
-	}
-	if (repoInfo.commitDiff.behind > 0) {
-		throw new Error(
-			`Your branch is behind the default branch by ${repoInfo.commitDiff.behind} commit(s). Please merge the default branch (git merge origin/${repoInfo.defaultBranch}) into your branch before creating a PR.`
-		)
-	}
-	if (!repoInfo.repoIsClean) {
-		throw new Error("Please pull, commit and push, or stash your changes before creating a PR.")
-	}
+  if (repoInfo.currentBranch === repoInfo.defaultBranch) {
+    throw new Error("You are currently on the default branch. Please switch to a feature branch to create a PR.")
+  }
+  if (repoInfo.commitDiff.behind > 0) {
+    throw new Error(
+      `Your branch is behind the default branch by ${repoInfo.commitDiff.behind} commit(s). Please merge the default branch (git merge origin/${repoInfo.defaultBranch}) into your branch before creating a PR.`
+    )
+  }
+  if (!repoInfo.repoIsClean) {
+    throw new Error("Please pull, commit and push, or stash your changes before creating a PR.")
+  }
 }
 
 export const repoIsReadyForRelease = (repoInfo: RepoInfo): void => {
-	if (repoInfo.currentBranch !== repoInfo.defaultBranch) {
-		throw new Error(`You are currently on branch ${repoInfo.currentBranch}. Please switch to the default branch (${repoInfo.defaultBranch}) to create a release.`)
-	}
-	if (!repoInfo.repoIsClean) {
-		throw new Error("Please pull, commit and push, stash, or branch out your changes before creating a release.")
-	}
+  if (repoInfo.currentBranch !== repoInfo.defaultBranch) {
+    throw new Error(`You are currently on branch ${repoInfo.currentBranch}. Please switch to the default branch (${repoInfo.defaultBranch}) to create a release.`)
+  }
+  if (!repoInfo.repoIsClean) {
+    throw new Error("Please pull, commit and push, stash, or branch out your changes before creating a release.")
+  }
 }
 
 export const getRepoInfo = (): RepoInfo => {
-	const remoteUrl: string = runGitCommand("git config --get remote.origin.url")
-	if (!(remoteUrl.startsWith("git@github.com:") || remoteUrl.startsWith("https://github.com/"))) {
-		throw new Error("Repository is not a GitHub repository. VFK CLI only supports GitHub for PR creation.")
-	}
-	fetchChangesAndTags()
-	const githubUrl: string = (remoteUrl.startsWith("git@") ? remoteUrl.replace("git@github.com:", "https://github.com/") : remoteUrl).replace(/\.git$/, "")
-	// git@github.com:<owner>/<repo>.git - SSH version
-	// https://github.com/<owner>/<repo>.git - HTTPS version
-	const githubUsername: string | undefined = getGithubUsername()
-	const currentBranch: string = getCurrentBranch()
-	const defaultBranch: string = getDefaultBranch()
-	const repoIsClean: boolean = isRepoClean()
-	const commitDiff: CommitsBehindAhead = getCommitsBehindAndAheadDefaultBranch()
+  const remoteUrl: string = runGitCommand("git config --get remote.origin.url")
+  if (!(remoteUrl.startsWith("git@github.com:") || remoteUrl.startsWith("https://github.com/"))) {
+    throw new Error("Repository is not a GitHub repository. VFK CLI only supports GitHub for PR creation.")
+  }
+  fetchChangesAndTags()
+  const githubUrl: string = (remoteUrl.startsWith("git@") ? remoteUrl.replace("git@github.com:", "https://github.com/") : remoteUrl).replace(/\.git$/, "")
+  // git@github.com:<owner>/<repo>.git - SSH version
+  // https://github.com/<owner>/<repo>.git - HTTPS version
+  const githubUsername: string | undefined = getGithubUsername()
+  const currentBranch: string = getCurrentBranch()
+  const defaultBranch: string = getDefaultBranch()
+  const repoIsClean: boolean = isRepoClean()
+  const commitDiff: CommitsBehindAhead = getCommitsBehindAndAheadDefaultBranch()
 
-	return {
-		remoteUrl,
-		githubUrl,
-		githubUsername,
-		currentBranch,
-		defaultBranch,
-		repoIsClean,
-		commitDiff
-	}
+  return {
+    remoteUrl,
+    githubUrl,
+    githubUsername,
+    currentBranch,
+    defaultBranch,
+    repoIsClean,
+    commitDiff
+  }
 }
 
 export const commitAndPush = (message: string): void => {
-	runGitCommand("git add .")
-	runGitCommand(`git commit -m "${message}"`)
-	const currentBranch: string = getCurrentBranch()
-	runGitCommand(`git push origin ${currentBranch} --quiet`)
+  runGitCommand("git add .")
+  runGitCommand(`git commit -m "${message}"`)
+  const currentBranch: string = getCurrentBranch()
+  runGitCommand(`git push origin ${currentBranch} --quiet`)
 }
 
 const commitSeparator = "%x00ENDOFCOMMIT%x00" // Nul-character as separator, as it is not allowed in commit messages
@@ -127,103 +127,103 @@ const commitOutputSeparator = "\x00ENDOFCOMMIT\x00"
 const commitPropertySeparator = "\x00"
 
 export const parseGitLogs = (rawLog: string): GitLogCommit[] => {
-	// Windows wraps all lines in single quotes for some reason, remove them from the start and end of the entire log if they are present
-	if (rawLog.startsWith("'") && rawLog.endsWith("'")) {
-		rawLog = rawLog.slice(1, -1)
-	}
-	const commitEntries: string[] = rawLog.split(commitOutputSeparator).filter((entry) => entry.trim() !== "")
+  // Windows wraps all lines in single quotes for some reason, remove them from the start and end of the entire log if they are present
+  if (rawLog.startsWith("'") && rawLog.endsWith("'")) {
+    rawLog = rawLog.slice(1, -1)
+  }
+  const commitEntries: string[] = rawLog.split(commitOutputSeparator).filter((entry) => entry.trim() !== "")
 
-	return commitEntries.map((entry: string) => {
-		// Windows
-		if (entry.startsWith("'\n'")) {
-			entry = entry.slice(3)
-		}
-		// UNIX
-		if (entry.startsWith("\n")) {
-			entry = entry.slice(1)
-		}
+  return commitEntries.map((entry: string) => {
+    // Windows
+    if (entry.startsWith("'\n'")) {
+      entry = entry.slice(3)
+    }
+    // UNIX
+    if (entry.startsWith("\n")) {
+      entry = entry.slice(1)
+    }
 
-		const properties: string[] = entry.split(commitPropertySeparator)
-		if (properties.length < prettyPropertyNamesInOrder.length) {
-			throw new Error("Pretty format and property names length mismatch, check prettyFormat and property names array (that they have same number of properties, and in same order)")
-		}
+    const properties: string[] = entry.split(commitPropertySeparator)
+    if (properties.length < prettyPropertyNamesInOrder.length) {
+      throw new Error("Pretty format and property names length mismatch, check prettyFormat and property names array (that they have same number of properties, and in same order)")
+    }
 
-		return {
-			hash: properties[0] as string,
-			authorName: properties[1] as string,
-			authorEmail: properties[2] as string,
-			subject: properties[3] as string,
-			body: properties[4] as string,
-			commitDate: properties[5] as string
-		}
-	})
+    return {
+      hash: properties[0] as string,
+      authorName: properties[1] as string,
+      authorEmail: properties[2] as string,
+      subject: properties[3] as string,
+      body: properties[4] as string,
+      commitDate: properties[5] as string
+    }
+  })
 }
 
 export const getCommitsSinceTag = (tagOrCommitHash: string | null | undefined): GitLogCommit[] => {
-	const log: string = tagOrCommitHash
-		? runGitCommand(`git log --pretty=format:'${prettyFormat}' ${tagOrCommitHash}..HEAD --date=iso-strict`)
-		: runGitCommand(`git log --pretty=format:'${prettyFormat}' --date=iso-strict`)
-	if (!log) {
-		return []
-	}
-	return parseGitLogs(log)
+  const log: string = tagOrCommitHash
+    ? runGitCommand(`git log --pretty=format:'${prettyFormat}' ${tagOrCommitHash}..HEAD --date=iso-strict`)
+    : runGitCommand(`git log --pretty=format:'${prettyFormat}' --date=iso-strict`)
+  if (!log) {
+    return []
+  }
+  return parseGitLogs(log)
 }
 
 export const getBranchSpecificCommits = (branchName: string): GitLogCommit[] => {
-	const defaultBranch: string = getDefaultBranch()
-	const log: string = runGitCommand(`git log --pretty=format:'${prettyFormat}' origin/${defaultBranch}..${branchName} --date=iso-strict`)
-	if (!log) {
-		return []
-	}
-	return parseGitLogs(log)
+  const defaultBranch: string = getDefaultBranch()
+  const log: string = runGitCommand(`git log --pretty=format:'${prettyFormat}' origin/${defaultBranch}..${branchName} --date=iso-strict`)
+  if (!log) {
+    return []
+  }
+  return parseGitLogs(log)
 }
 
 /**
  * Maps semantic versioning release types to arrays of conventional commit keywords.
  */
 type ConventionalCommitTypes = {
-	major: string[]
-	minor: string[]
-	patch: string[]
-	maintenance: string[]
+  major: string[]
+  minor: string[]
+  patch: string[]
+  maintenance: string[]
 }
 
 export const conventionalCommitTypes: ConventionalCommitTypes = {
-	major: ["breaking change", "breaking", "major", "feat!", "fix!"],
-	minor: ["feat", "minor"],
-	patch: ["fix", "perf", "patch"],
-	maintenance: ["test", "style", "docs", "chore", "refactor"]
+  major: ["breaking change", "breaking", "major", "feat!", "fix!"],
+  minor: ["feat", "minor"],
+  patch: ["fix", "perf", "patch"],
+  maintenance: ["test", "style", "docs", "chore", "refactor"]
 }
 
 const getCommitType = (message: string): GitCommitType => {
-	message = message.trim().toLowerCase()
-	for (const [type, keywords] of Object.entries(conventionalCommitTypes)) {
-		for (const keyword of keywords) {
-			// Check for keyword at the start or after type(scope)
-			const regex = new RegExp(`^${keyword}(\\(.+\\))?(!)?(:| -|$)`, "i")
-			if (regex.test(message)) {
-				return type as GitCommitType
-			}
-		}
-	}
-	return "other"
+  message = message.trim().toLowerCase()
+  for (const [type, keywords] of Object.entries(conventionalCommitTypes)) {
+    for (const keyword of keywords) {
+      // Check for keyword at the start or after type(scope)
+      const regex = new RegExp(`^${keyword}(\\(.+\\))?(!)?(:| -|$)`, "i")
+      if (regex.test(message)) {
+        return type as GitCommitType
+      }
+    }
+  }
+  return "other"
 }
 
 export const sortCommitsByType = (commits: GitLogCommit[]): SortedCommits => {
-	const sorted: SortedCommits = {
-		major: [],
-		minor: [],
-		patch: [],
-		maintenance: [],
-		other: []
-	}
-	for (const commit of commits) {
-		const type: GitCommitType = getCommitType(commit.subject)
-		sorted[type].push(commit)
-	}
-	// Sort all arrays by commit date descending
-	for (const key of Object.keys(sorted) as (keyof SortedCommits)[]) {
-		sorted[key] = sorted[key].sort((a: GitLogCommit, b: GitLogCommit) => b.commitDate.localeCompare(a.commitDate))
-	}
-	return sorted
+  const sorted: SortedCommits = {
+    major: [],
+    minor: [],
+    patch: [],
+    maintenance: [],
+    other: []
+  }
+  for (const commit of commits) {
+    const type: GitCommitType = getCommitType(commit.subject)
+    sorted[type].push(commit)
+  }
+  // Sort all arrays by commit date descending
+  for (const key of Object.keys(sorted) as (keyof SortedCommits)[]) {
+    sorted[key] = sorted[key].sort((a: GitLogCommit, b: GitLogCommit) => b.commitDate.localeCompare(a.commitDate))
+  }
+  return sorted
 }

--- a/src/lib/open-url.ts
+++ b/src/lib/open-url.ts
@@ -1,39 +1,39 @@
 import { type ChildProcess, spawn } from "node:child_process"
 
 export const openUrl = (url: string, message: string = ""): void => {
-	let command: string
-	let args: string[]
+  let command: string
+  let args: string[]
 
-	url = url.replaceAll("(", "%28").replaceAll(")", "%29")
+  url = url.replaceAll("(", "%28").replaceAll(")", "%29")
 
-	switch (process.platform) {
-		case "darwin": // macOS
-			command = "open"
-			args = [url]
-			break
-		case "win32": // Windows
-			command = "cmd.exe"
-			args = ["/c", "start", '""', url.replaceAll("&", "^&")]
-			break
-		default: // Linux and other POSIX-like systems
-			command = `xdg-open`
-			args = [url]
-			break
-	}
+  switch (process.platform) {
+    case "darwin": // macOS
+      command = "open"
+      args = [url]
+      break
+    case "win32": // Windows
+      command = "cmd.exe"
+      args = ["/c", "start", '""', url.replaceAll("&", "^&")]
+      break
+    default: // Linux and other POSIX-like systems
+      command = `xdg-open`
+      args = [url]
+      break
+  }
 
-	const childProcess: ChildProcess = spawn(command, args, { stdio: "inherit" })
+  const childProcess: ChildProcess = spawn(command, args, { stdio: "inherit" })
 
-	childProcess.on("error", (error: Error) => {
-		console.error(`Error opening URL: ${error.message}`)
-	})
+  childProcess.on("error", (error: Error) => {
+    console.error(`Error opening URL: ${error.message}`)
+  })
 
-	childProcess.on("close", (code: number | null) => {
-		if (code === null || code !== 0) {
-			console.error(`Error opening URL. Process exited with code ${code}`)
-			return
-		}
+  childProcess.on("close", (code: number | null) => {
+    if (code === null || code !== 0) {
+      console.error(`Error opening URL. Process exited with code ${code}`)
+      return
+    }
 
-		const messageStr: string = message.length > 0 ? `${message}: ` : ""
-		console.log(`${messageStr}${url}`)
-	})
+    const messageStr: string = message.length > 0 ? `${message}: ` : ""
+    console.log(`${messageStr}${url}`)
+  })
 }

--- a/src/lib/release-notes.ts
+++ b/src/lib/release-notes.ts
@@ -5,53 +5,53 @@ import { sortCommitsByType } from "./git.js"
 const capitalize = (str: string): string => str.charAt(0).toUpperCase() + str.slice(1).toLowerCase()
 
 type EmojisByType = {
-	[key in keyof SortedCommits]: string
+  [key in keyof SortedCommits]: string
 }
 
 const emojisByType: EmojisByType = {
-	major: "🚨",
-	minor: "✨",
-	patch: "🐛",
-	maintenance: "🛠️",
-	other: "🤦‍♂️"
+  major: "🚨",
+  minor: "✨",
+  patch: "🐛",
+  maintenance: "🛠️",
+  other: "🤦‍♂️"
 }
 
 export const generateCommitNotes = (sortedCommits: SortedCommits): string => {
-	let notes: string = ""
-	// Loop through each commit type and add to notes
-	for (const [type, commits] of Object.entries(sortedCommits) as [keyof SortedCommits, SortedCommits[keyof SortedCommits]][]) {
-		if (commits.length === 0) {
-			continue
-		}
+  let notes: string = ""
+  // Loop through each commit type and add to notes
+  for (const [type, commits] of Object.entries(sortedCommits) as [keyof SortedCommits, SortedCommits[keyof SortedCommits]][]) {
+    if (commits.length === 0) {
+      continue
+    }
 
-		notes += `### ${emojisByType[type]} **${capitalize(type)} Changes:**\n\n`
-		for (const commit of commits) {
-			notes += `- ${commit.subject} (${commit.hash})\n`
-		}
-		notes += "\n"
-	}
-	return notes.trim()
+    notes += `### ${emojisByType[type]} **${capitalize(type)} Changes:**\n\n`
+    for (const commit of commits) {
+      notes += `- ${commit.subject} (${commit.hash})\n`
+    }
+    notes += "\n"
+  }
+  return notes.trim()
 }
 
 /**
  * Generates release notes based on the provided release data.
  */
 export const generateReleaseNotes = (releaseData: ReleaseData): string => {
-	if (!releaseData.releaseType || !releaseData.projectInfo) {
-		throw new Error("releaseType and projectInfo are required to generate release notes")
-	}
-	if (releaseData.releaseType === "initial-release") {
-		let notes: string = "Initial release. 👶\n\n"
-		if (releaseData.projectInfo.version !== "1.0.0") {
-			notes += `Remark: No previous release was found, but project version is greater than 1.0.0, starting release tag from project version: ${releaseData.projectInfo.version}.\n\n`
-		}
-		return notes
-	}
+  if (!releaseData.releaseType || !releaseData.projectInfo) {
+    throw new Error("releaseType and projectInfo are required to generate release notes")
+  }
+  if (releaseData.releaseType === "initial-release") {
+    let notes: string = "Initial release. 👶\n\n"
+    if (releaseData.projectInfo.version !== "1.0.0") {
+      notes += `Remark: No previous release was found, but project version is greater than 1.0.0, starting release tag from project version: ${releaseData.projectInfo.version}.\n\n`
+    }
+    return notes
+  }
 
-	if (!releaseData.commits || releaseData.commits.length === 0) {
-		throw new Error("No commits in releaseData, something is wrong...")
-	}
+  if (!releaseData.commits || releaseData.commits.length === 0) {
+    throw new Error("No commits in releaseData, something is wrong...")
+  }
 
-	const sortedCommits: SortedCommits = sortCommitsByType(releaseData.commits)
-	return generateCommitNotes(sortedCommits)
+  const sortedCommits: SortedCommits = sortCommitsByType(releaseData.commits)
+  return generateCommitNotes(sortedCommits)
 }

--- a/src/lib/run-tests.ts
+++ b/src/lib/run-tests.ts
@@ -2,16 +2,16 @@ import { execSync } from "node:child_process"
 import type { ProjectInfo } from "../types/semver.js"
 
 export const runTests = (projectInfo: ProjectInfo): void => {
-	switch (projectInfo.type) {
-		case "node": {
-			execSync("npm test")
-			break
-		}
-		case "dotnet": {
-			execSync("dotnet test")
-			break
-		}
-		default:
-			throw new Error(`Unsupported project type for running tests: ${projectInfo.type}`)
-	}
+  switch (projectInfo.type) {
+    case "node": {
+      execSync("npm test")
+      break
+    }
+    case "dotnet": {
+      execSync("dotnet test")
+      break
+    }
+    default:
+      throw new Error(`Unsupported project type for running tests: ${projectInfo.type}`)
+  }
 }

--- a/src/lib/semver.ts
+++ b/src/lib/semver.ts
@@ -6,100 +6,100 @@ import type { NextVersion, ProjectInfo, ReleaseType } from "../types/semver.js"
 import type { SupportedSemverType } from "../types/tools.js"
 
 type DotnetProjVersionInfo = {
-	version: string | undefined
-	path: string
+  version: string | undefined
+  path: string
 }
 
 export const SUPPORTED_SEMVER_TYPES_BY_PRIORITY: SupportedSemverType[] = ["major", "minor", "patch"]
 
 export const getLatestSemverTag = (tags: string[]): string | null => {
-	const semverTags: string[] = tags.filter((tag) => semver.valid(tag))
-	return semver.maxSatisfying(semverTags, "*", { includePrerelease: true })
+  const semverTags: string[] = tags.filter((tag) => semver.valid(tag))
+  return semver.maxSatisfying(semverTags, "*", { includePrerelease: true })
 }
 
 export const getProjectInfo = (): ProjectInfo => {
-	// Read project version from relevant file based on project type
-	// Node.js - package.json
-	if (existsSync("./package.json")) {
-		const pkg = JSON.parse(readFileSync("./package.json", "utf-8"))
-		if (!semver.valid(pkg.version)) {
-			throw new Error(`Invalid semver version in package.json: ${pkg.version}, please fix it manually before proceeding...`)
-		}
+  // Read project version from relevant file based on project type
+  // Node.js - package.json
+  if (existsSync("./package.json")) {
+    const pkg = JSON.parse(readFileSync("./package.json", "utf-8"))
+    if (!semver.valid(pkg.version)) {
+      throw new Error(`Invalid semver version in package.json: ${pkg.version}, please fix it manually before proceeding...`)
+    }
 
-		const paths: string[] = ["./package.json"]
-		if (existsSync("./package-lock.json")) {
-			paths.push("./package-lock.json")
-		}
+    const paths: string[] = ["./package.json"]
+    if (existsSync("./package-lock.json")) {
+      paths.push("./package-lock.json")
+    }
 
-		return {
-			version: pkg.version,
-			type: "node",
-			paths,
-			name: pkg.name
-		}
-	}
+    return {
+      version: pkg.version,
+      type: "node",
+      paths,
+      name: pkg.name
+    }
+  }
 
-	// .NET - .csproj
-	const csProjFiles = readdirSync("./", { recursive: true }).filter((filename) => typeof filename === "string" && filename.endsWith(".csproj") && !filename.match(/\/bin\/|\/obj\//))
-	if (!csProjFiles.every((file) => typeof file === "string")) {
-		throw new Error("Error reading .csproj files, not all filenames are strings.")
-	}
+  // .NET - .csproj
+  const csProjFiles = readdirSync("./", { recursive: true }).filter((filename) => typeof filename === "string" && filename.endsWith(".csproj") && !filename.match(/\/bin\/|\/obj\//))
+  if (!csProjFiles.every((file) => typeof file === "string")) {
+    throw new Error("Error reading .csproj files, not all filenames are strings.")
+  }
 
-	if (csProjFiles.length > 0) {
-		const versions: DotnetProjVersionInfo[] | null = csProjFiles
-			.map((file: string) => {
-				const content: string = readFileSync(`./${file}`, "utf-8")
-				const match: RegExpMatchArray | null = content.match(/<Version>(.*?)<\/Version>/)
-				return match ? { version: match[1], path: file } : null
-			})
-			.filter((v: DotnetProjVersionInfo | null) => v !== null)
+  if (csProjFiles.length > 0) {
+    const versions: DotnetProjVersionInfo[] | null = csProjFiles
+      .map((file: string) => {
+        const content: string = readFileSync(`./${file}`, "utf-8")
+        const match: RegExpMatchArray | null = content.match(/<Version>(.*?)<\/Version>/)
+        return match ? { version: match[1], path: file } : null
+      })
+      .filter((v: DotnetProjVersionInfo | null) => v !== null)
 
-		if (versions.length > 1) {
-			throw new Error(`Multiple .csproj files with version tag found in solution: ${versions.map((version: DotnetProjVersionInfo) => version.path).join(", ")}`)
-		}
+    if (versions.length > 1) {
+      throw new Error(`Multiple .csproj files with version tag found in solution: ${versions.map((version: DotnetProjVersionInfo) => version.path).join(", ")}`)
+    }
 
-		if (versions.length === 0) {
-			throw new Error("No <Version> tag found in any .csproj file.")
-		}
+    if (versions.length === 0) {
+      throw new Error("No <Version> tag found in any .csproj file.")
+    }
 
-		if (!semver.valid(versions[0]?.version)) {
-			throw new Error(`Invalid semver version in ${versions[0]?.path}: ${versions[0]?.version}, please fix it manually before proceeding...`)
-		}
+    if (!semver.valid(versions[0]?.version)) {
+      throw new Error(`Invalid semver version in ${versions[0]?.path}: ${versions[0]?.version}, please fix it manually before proceeding...`)
+    }
 
-		if (!versions[0]?.path) {
-			throw new Error("Error reading .csproj file path.")
-		}
+    if (!versions[0]?.path) {
+      throw new Error("Error reading .csproj file path.")
+    }
 
-		return {
-			version: versions[0].version as string, // We know it's defined here, as semver.valid passed
-			type: "dotnet",
-			paths: [versions[0].path as string]
-		}
-	}
+    return {
+      version: versions[0].version as string, // We know it's defined here, as semver.valid passed
+      type: "dotnet",
+      paths: [versions[0].path as string]
+    }
+  }
 
-	// Add more project types as needed
-	throw new Error("Unsupported project type for version retrieval.")
+  // Add more project types as needed
+  throw new Error("Unsupported project type for version retrieval.")
 }
 
 const hasBeenIncreasedOneTime = (semver1: string, semver2: string): boolean => {
-	const diffType: semver.ReleaseType | null = semver.diff(semver1, semver2) // 'major', 'minor', 'patch', 'premajor', 'preminor', 'prepatch', 'prerelease' or null
-	if (!diffType) {
-		return false
-	}
+  const diffType: semver.ReleaseType | null = semver.diff(semver1, semver2) // 'major', 'minor', 'patch', 'premajor', 'preminor', 'prepatch', 'prerelease' or null
+  if (!diffType) {
+    return false
+  }
 
-	const incrementedVersion: string | null = semver.inc(semver1, diffType)
-	return incrementedVersion === semver2
+  const incrementedVersion: string | null = semver.inc(semver1, diffType)
+  return incrementedVersion === semver2
 }
 
 export const useExistingProjectVersion = (latestTag: string, projectVersion: string, releaseType: SupportedSemverType): boolean => {
-	if (!semver.valid(latestTag) || !semver.valid(projectVersion)) {
-		return false
-	}
-	if (!hasBeenIncreasedOneTime(latestTag, projectVersion)) {
-		return false
-	}
+  if (!semver.valid(latestTag) || !semver.valid(projectVersion)) {
+    return false
+  }
+  if (!hasBeenIncreasedOneTime(latestTag, projectVersion)) {
+    return false
+  }
 
-	return !semver.lt(projectVersion, semver.inc(latestTag, releaseType) as string) // We already checked that both projectVersion and latestTag are valid above
+  return !semver.lt(projectVersion, semver.inc(latestTag, releaseType) as string) // We already checked that both projectVersion and latestTag are valid above
 }
 
 /**
@@ -109,90 +109,90 @@ export const useExistingProjectVersion = (latestTag: string, projectVersion: str
  * Favors the latest semver tag, and fallbacks to project version if semver tag is not present.
  */
 export const getNextVersion = (latestTag: string | null, projectInfo: ProjectInfo, releaseType: SupportedSemverType): NextVersion => {
-	if (!semver.valid(projectInfo.version) && !semver.valid(latestTag)) {
-		throw new Error("No valid version found from latest tag or project version.")
-	}
+  if (!semver.valid(projectInfo.version) && !semver.valid(latestTag)) {
+    throw new Error("No valid version found from latest tag or project version.")
+  }
 
-	if (latestTag && semver.valid(latestTag)) {
-		// Check if project version already has been bumped one time from latest tag - if so, someone else has already merged to main before the release
-		if (projectInfo.version && semver.valid(projectInfo.version) && useExistingProjectVersion(latestTag, projectInfo.version, releaseType)) {
-			return {
-				version: projectInfo.version,
-				isInitialRelease: false,
-				source: "project-already-bumped",
-				description: "Project version has already been bumped sufficiently from latest tag"
-			}
-		}
+  if (latestTag && semver.valid(latestTag)) {
+    // Check if project version already has been bumped one time from latest tag - if so, someone else has already merged to main before the release
+    if (projectInfo.version && semver.valid(projectInfo.version) && useExistingProjectVersion(latestTag, projectInfo.version, releaseType)) {
+      return {
+        version: projectInfo.version,
+        isInitialRelease: false,
+        source: "project-already-bumped",
+        description: "Project version has already been bumped sufficiently from latest tag"
+      }
+    }
 
-		return {
-			version: semver.inc(latestTag, releaseType) as string,
-			isInitialRelease: false,
-			source: "tag",
-			description: `Increased ${releaseType} from latest tag ${latestTag}`
-		}
-	}
+    return {
+      version: semver.inc(latestTag, releaseType) as string,
+      isInitialRelease: false,
+      source: "tag",
+      description: `Increased ${releaseType} from latest tag ${latestTag}`
+    }
+  }
 
-	const isInitialRelease: boolean = projectInfo.version === "1.0.0"
-	return {
-		version: isInitialRelease ? "1.0.0" : (semver.inc(projectInfo.version as string, releaseType) as string), // We also know that projectInfo.version is valid here
-		isInitialRelease,
-		source: "project",
-		description: `No valid latest tag found, using project version as base`
-	}
+  const isInitialRelease: boolean = projectInfo.version === "1.0.0"
+  return {
+    version: isInitialRelease ? "1.0.0" : (semver.inc(projectInfo.version as string, releaseType) as string), // We also know that projectInfo.version is valid here
+    isInitialRelease,
+    source: "project",
+    description: `No valid latest tag found, using project version as base`
+  }
 }
 
 export const updateProjectVersion = (projectInfo: ProjectInfo, newVersion: string): void => {
-	if (!semver.valid(newVersion)) {
-		throw new Error(`Invalid semver version for new version: ${newVersion}`)
-	}
+  if (!semver.valid(newVersion)) {
+    throw new Error(`Invalid semver version for new version: ${newVersion}`)
+  }
 
-	switch (projectInfo.type) {
-		case "node": {
-			for (const path of projectInfo.paths) {
-				// We do not parse JSON to preserve formatting yes
-				const content: string = readFileSync(path, "utf-8")
-				if (!projectInfo.name) {
-					throw new Error("Project name is required to update version.")
-				}
+  switch (projectInfo.type) {
+    case "node": {
+      for (const path of projectInfo.paths) {
+        // We do not parse JSON to preserve formatting yes
+        const content: string = readFileSync(path, "utf-8")
+        if (!projectInfo.name) {
+          throw new Error("Project name is required to update version.")
+        }
 
-				const newContent: string = content.replace(new RegExp(`("name": "${projectInfo.name}",\\s+"version": ")[^"]*(")`, "g"), (_: string, prefix: string, suffix: string): string => {
-					return `${prefix}${newVersion}${suffix}`
-				})
-				writeFileSync(path, newContent, "utf-8")
-			}
-			break
-		}
-		case "dotnet": {
-			for (const path of projectInfo.paths) {
-				const content: string = readFileSync(path, "utf-8")
-				const newContent: string = content.replace(/<Version>(.*?)<\/Version>/, `<Version>${newVersion}</Version>`)
-				writeFileSync(path, newContent, "utf-8")
-			}
-			break
-		}
-		default:
-			throw new Error(`Unsupported project type: ${projectInfo.type}`)
-	}
+        const newContent: string = content.replace(new RegExp(`("name": "${projectInfo.name}",\\s+"version": ")[^"]*(")`, "g"), (_: string, prefix: string, suffix: string): string => {
+          return `${prefix}${newVersion}${suffix}`
+        })
+        writeFileSync(path, newContent, "utf-8")
+      }
+      break
+    }
+    case "dotnet": {
+      for (const path of projectInfo.paths) {
+        const content: string = readFileSync(path, "utf-8")
+        const newContent: string = content.replace(/<Version>(.*?)<\/Version>/, `<Version>${newVersion}</Version>`)
+        writeFileSync(path, newContent, "utf-8")
+      }
+      break
+    }
+    default:
+      throw new Error(`Unsupported project type: ${projectInfo.type}`)
+  }
 }
 
 export const getSemverReleaseType = (latestTag: string | null, projectInfo: ProjectInfo): ReleaseType => {
-	if (!projectInfo.version || !semver.valid(projectInfo.version)) {
-		throw new Error("Cannot determine semver type without a valid project version. Please fix it manually.")
-	}
-	if (!latestTag || !semver.valid(latestTag)) {
-		return "initial-release"
-	}
-	if (!hasBeenIncreasedOneTime(latestTag, projectInfo.version)) {
-		throw new Error(`Project version ${projectInfo.version} has not been bumped correctly from latest tag ${latestTag}. Please fix it manually.`)
-	}
+  if (!projectInfo.version || !semver.valid(projectInfo.version)) {
+    throw new Error("Cannot determine semver type without a valid project version. Please fix it manually.")
+  }
+  if (!latestTag || !semver.valid(latestTag)) {
+    return "initial-release"
+  }
+  if (!hasBeenIncreasedOneTime(latestTag, projectInfo.version)) {
+    throw new Error(`Project version ${projectInfo.version} has not been bumped correctly from latest tag ${latestTag}. Please fix it manually.`)
+  }
 
-	const semverType: semver.ReleaseType | null = semver.diff(latestTag, projectInfo.version)
-	if (!semverType) {
-		throw new Error("Cannot determine semver type from latest tag and project version. Please fix it manually.")
-	}
-	if (!SUPPORTED_SEMVER_TYPES_BY_PRIORITY.includes(semverType as SupportedSemverType)) {
-		throw new Error(`Unsupported semver difference type: ${semverType}. Must be one of ${SUPPORTED_SEMVER_TYPES_BY_PRIORITY.join(", ")}. Please fix it manually.`)
-	}
+  const semverType: semver.ReleaseType | null = semver.diff(latestTag, projectInfo.version)
+  if (!semverType) {
+    throw new Error("Cannot determine semver type from latest tag and project version. Please fix it manually.")
+  }
+  if (!SUPPORTED_SEMVER_TYPES_BY_PRIORITY.includes(semverType as SupportedSemverType)) {
+    throw new Error(`Unsupported semver difference type: ${semverType}. Must be one of ${SUPPORTED_SEMVER_TYPES_BY_PRIORITY.join(", ")}. Please fix it manually.`)
+  }
 
-	return semverType as ReleaseType
+  return semverType as ReleaseType
 }

--- a/src/lib/semver.ts
+++ b/src/lib/semver.ts
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { execSync } from "node:child_process"
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs"
 import semver from "semver"
 import type { NextVersion, ProjectInfo, ReleaseType } from "../types/semver.js"
@@ -148,18 +149,16 @@ export const updateProjectVersion = (projectInfo: ProjectInfo, newVersion: strin
 
   switch (projectInfo.type) {
     case "node": {
-      for (const path of projectInfo.paths) {
-        // We do not parse JSON to preserve formatting yes
-        const content: string = readFileSync(path, "utf-8")
-        if (!projectInfo.name) {
-          throw new Error("Project name is required to update version.")
-        }
-
-        const newContent: string = content.replace(new RegExp(`("name": "${projectInfo.name}",\\s+"version": ")[^"]*(")`, "g"), (_: string, prefix: string, suffix: string): string => {
-          return `${prefix}${newVersion}${suffix}`
-        })
-        writeFileSync(path, newContent, "utf-8")
+      if (!projectInfo.name) {
+        throw new Error("Project name is required to update version.")
       }
+
+      // use builtin npm command to bump project version
+      execSync(`npm version ${newVersion} --no-git-tag-version`, {
+        timeout: 5000, // Maximum execution time in milliseconds
+        killSignal: "SIGKILL", // Forces termination if SIGTERM is ignored (Optional)
+        encoding: "utf8" // Returns output as string instead of Buffer
+      })
       break
     }
     case "dotnet": {

--- a/src/tests/git.test.ts
+++ b/src/tests/git.test.ts
@@ -16,108 +16,108 @@ Hvordan går det ❤️\x002025-11-03T14:12:33+01:00\x00ENDOFCOMMIT\x00'
 'commithash3\x00Franken Stein\x00franken.stein@smyger.no\x00chore: bump version to 3.3.1\x00\x002025-10-29T13:06:56+01:00\x00ENDOFCOMMIT\x00'`
 
 describe("parseGitLogs", () => {
-	it("should parse unix and windows git logs into structured commits", () => {
-		const unixCommits: GitLogCommit[] = parseGitLogs(rawUnixLog)
-		const windowsCommits: GitLogCommit[] = parseGitLogs(rawWindowsLog)
+  it("should parse unix and windows git logs into structured commits", () => {
+    const unixCommits: GitLogCommit[] = parseGitLogs(rawUnixLog)
+    const windowsCommits: GitLogCommit[] = parseGitLogs(rawWindowsLog)
 
-		assert.strictEqual(unixCommits.length, 3)
-		assert.strictEqual(windowsCommits.length, 3)
+    assert.strictEqual(unixCommits.length, 3)
+    assert.strictEqual(windowsCommits.length, 3)
 
-		assert.deepStrictEqual(unixCommits[0], {
-			hash: "commithash1",
-			authorName: "Franken Stein",
-			authorEmail: "franken.stein@smyger.no",
-			subject: "Merge remote-tracking branch 'origin/main' into mordor",
-			body: "",
-			commitDate: "2025-11-03T14:13:00+01:00"
-		})
-		assert.deepStrictEqual(windowsCommits[0], {
-			hash: "commithash1",
-			authorName: "Franken Stein",
-			authorEmail: "franken.stein@smyger.no",
-			subject: "Merge remote-tracking branch 'origin/main' into mordor",
-			body: "",
-			commitDate: "2025-11-03T14:13:00+01:00"
-		})
+    assert.deepStrictEqual(unixCommits[0], {
+      hash: "commithash1",
+      authorName: "Franken Stein",
+      authorEmail: "franken.stein@smyger.no",
+      subject: "Merge remote-tracking branch 'origin/main' into mordor",
+      body: "",
+      commitDate: "2025-11-03T14:13:00+01:00"
+    })
+    assert.deepStrictEqual(windowsCommits[0], {
+      hash: "commithash1",
+      authorName: "Franken Stein",
+      authorEmail: "franken.stein@smyger.no",
+      subject: "Merge remote-tracking branch 'origin/main' into mordor",
+      body: "",
+      commitDate: "2025-11-03T14:13:00+01:00"
+    })
 
-		assert.deepStrictEqual(unixCommits[1], {
-			hash: "commithash2",
-			authorName: "franky",
-			authorEmail: "franken.stein@smyger.no",
-			subject: "En commit med body",
-			body: "Jeg er Franky!\n\nHvordan går det ❤️",
-			commitDate: "2025-11-03T14:12:33+01:00"
-		})
-		assert.deepStrictEqual(windowsCommits[1], {
-			hash: "commithash2",
-			authorName: "franky",
-			authorEmail: "franken.stein@smyger.no",
-			subject: "En commit med body",
-			body: "Jeg er Franky!\n\nHvordan går det ❤️",
-			commitDate: "2025-11-03T14:12:33+01:00"
-		})
+    assert.deepStrictEqual(unixCommits[1], {
+      hash: "commithash2",
+      authorName: "franky",
+      authorEmail: "franken.stein@smyger.no",
+      subject: "En commit med body",
+      body: "Jeg er Franky!\n\nHvordan går det ❤️",
+      commitDate: "2025-11-03T14:12:33+01:00"
+    })
+    assert.deepStrictEqual(windowsCommits[1], {
+      hash: "commithash2",
+      authorName: "franky",
+      authorEmail: "franken.stein@smyger.no",
+      subject: "En commit med body",
+      body: "Jeg er Franky!\n\nHvordan går det ❤️",
+      commitDate: "2025-11-03T14:12:33+01:00"
+    })
 
-		assert.deepStrictEqual(unixCommits[2], {
-			hash: "commithash3",
-			authorName: "Franken Stein",
-			authorEmail: "franken.stein@smyger.no",
-			subject: "chore: bump version to 3.3.1",
-			body: "",
-			commitDate: "2025-10-29T13:06:56+01:00"
-		})
-		assert.deepStrictEqual(windowsCommits[2], {
-			hash: "commithash3",
-			authorName: "Franken Stein",
-			authorEmail: "franken.stein@smyger.no",
-			subject: "chore: bump version to 3.3.1",
-			body: "",
-			commitDate: "2025-10-29T13:06:56+01:00"
-		})
-	})
+    assert.deepStrictEqual(unixCommits[2], {
+      hash: "commithash3",
+      authorName: "Franken Stein",
+      authorEmail: "franken.stein@smyger.no",
+      subject: "chore: bump version to 3.3.1",
+      body: "",
+      commitDate: "2025-10-29T13:06:56+01:00"
+    })
+    assert.deepStrictEqual(windowsCommits[2], {
+      hash: "commithash3",
+      authorName: "Franken Stein",
+      authorEmail: "franken.stein@smyger.no",
+      subject: "chore: bump version to 3.3.1",
+      body: "",
+      commitDate: "2025-10-29T13:06:56+01:00"
+    })
+  })
 
-	it("should return empty array for empty log", () => {
-		const commits: GitLogCommit[] = parseGitLogs("")
+  it("should return empty array for empty log", () => {
+    const commits: GitLogCommit[] = parseGitLogs("")
 
-		assert.strictEqual(commits.length, 0)
-	})
+    assert.strictEqual(commits.length, 0)
+  })
 })
 
 // Check that sortCommitsByType and getCommitType works as expected
 describe("sortCommitsByType", () => {
-	it("should sort commits by type correctly", () => {
-		const commits: GitLogCommit[] = [
-			{ hash: "hash1", authorName: "Author", authorEmail: "author@example.com", subject: "feat: add new feature", body: "", commitDate: "2025-11-11T10:00:00Z" }, // Should be first minor
-			{ hash: "hash2", authorName: "Author", authorEmail: "author@example.com", subject: "fix - fix a bug", body: "", commitDate: "2025-11-02T10:00:00Z" }, // Should be first patch
-			{ hash: "hash3", authorName: "Author", authorEmail: "author@example.com", subject: "chore: update dependencies", body: "", commitDate: "2025-12-03T10:00:00Z" }, // Should be first maintenance
-			{ hash: "hash4", authorName: "Author", authorEmail: "author@example.com", subject: "docs: update README", body: "", commitDate: "2025-11-10T10:00:00Z" }, // Should be second maintenance
-			{ hash: "hash5", authorName: "Author", authorEmail: "author@example.com", subject: "refactor - improve code structure", body: "", commitDate: "2025-11-05T10:00:00Z" }, // Should be third maintenance
-			{ hash: "hash6", authorName: "Author", authorEmail: "author@example.com", subject: "perf: improve performance", body: "", commitDate: "2025-11-01T10:00:00Z" }, // Should be second patch
-			{ hash: "hash7", authorName: "Author", authorEmail: "author@example.com", subject: "breaking change: overhaul API", body: "", commitDate: "2025-11-07T10:00:00Z" }, // Should be only major
-			{ hash: "hash8", authorName: "Author", authorEmail: "author@example.com", subject: "minor: add minor improvement", body: "", commitDate: "2025-11-08T08:00:00Z" }, // Should be second minor
-			{ hash: "hash9", authorName: "Author", authorEmail: "author@example.com", subject: "unknown type commit", body: "", commitDate: "2025-11-09T10:00:00Z" }, // Should be only other
-			{ hash: "hash10", authorName: "Author", authorEmail: "author@example.com", subject: "chore frankestein type commit", body: "", commitDate: "2025-11-08T10:00:00Z" } // Should be the second other
-		]
+  it("should sort commits by type correctly", () => {
+    const commits: GitLogCommit[] = [
+      { hash: "hash1", authorName: "Author", authorEmail: "author@example.com", subject: "feat: add new feature", body: "", commitDate: "2025-11-11T10:00:00Z" }, // Should be first minor
+      { hash: "hash2", authorName: "Author", authorEmail: "author@example.com", subject: "fix - fix a bug", body: "", commitDate: "2025-11-02T10:00:00Z" }, // Should be first patch
+      { hash: "hash3", authorName: "Author", authorEmail: "author@example.com", subject: "chore: update dependencies", body: "", commitDate: "2025-12-03T10:00:00Z" }, // Should be first maintenance
+      { hash: "hash4", authorName: "Author", authorEmail: "author@example.com", subject: "docs: update README", body: "", commitDate: "2025-11-10T10:00:00Z" }, // Should be second maintenance
+      { hash: "hash5", authorName: "Author", authorEmail: "author@example.com", subject: "refactor - improve code structure", body: "", commitDate: "2025-11-05T10:00:00Z" }, // Should be third maintenance
+      { hash: "hash6", authorName: "Author", authorEmail: "author@example.com", subject: "perf: improve performance", body: "", commitDate: "2025-11-01T10:00:00Z" }, // Should be second patch
+      { hash: "hash7", authorName: "Author", authorEmail: "author@example.com", subject: "breaking change: overhaul API", body: "", commitDate: "2025-11-07T10:00:00Z" }, // Should be only major
+      { hash: "hash8", authorName: "Author", authorEmail: "author@example.com", subject: "minor: add minor improvement", body: "", commitDate: "2025-11-08T08:00:00Z" }, // Should be second minor
+      { hash: "hash9", authorName: "Author", authorEmail: "author@example.com", subject: "unknown type commit", body: "", commitDate: "2025-11-09T10:00:00Z" }, // Should be only other
+      { hash: "hash10", authorName: "Author", authorEmail: "author@example.com", subject: "chore frankestein type commit", body: "", commitDate: "2025-11-08T10:00:00Z" } // Should be the second other
+    ]
 
-		const sorted: SortedCommits = sortCommitsByType(commits)
+    const sorted: SortedCommits = sortCommitsByType(commits)
 
-		assert.strictEqual(sorted.major.length, 1)
-		assert.strictEqual(sorted.major[0]?.subject, "breaking change: overhaul API")
+    assert.strictEqual(sorted.major.length, 1)
+    assert.strictEqual(sorted.major[0]?.subject, "breaking change: overhaul API")
 
-		assert.strictEqual(sorted.minor.length, 2)
-		assert.strictEqual(sorted.minor[0]?.subject, "feat: add new feature")
-		assert.strictEqual(sorted.minor[1]?.subject, "minor: add minor improvement")
+    assert.strictEqual(sorted.minor.length, 2)
+    assert.strictEqual(sorted.minor[0]?.subject, "feat: add new feature")
+    assert.strictEqual(sorted.minor[1]?.subject, "minor: add minor improvement")
 
-		assert.strictEqual(sorted.patch.length, 2)
-		assert.strictEqual(sorted.patch[0]?.subject, "fix - fix a bug")
-		assert.strictEqual(sorted.patch[1]?.subject, "perf: improve performance")
+    assert.strictEqual(sorted.patch.length, 2)
+    assert.strictEqual(sorted.patch[0]?.subject, "fix - fix a bug")
+    assert.strictEqual(sorted.patch[1]?.subject, "perf: improve performance")
 
-		assert.strictEqual(sorted.maintenance.length, 3)
-		assert.strictEqual(sorted.maintenance[0]?.subject, "chore: update dependencies")
-		assert.strictEqual(sorted.maintenance[1]?.subject, "docs: update README")
-		assert.strictEqual(sorted.maintenance[2]?.subject, "refactor - improve code structure")
+    assert.strictEqual(sorted.maintenance.length, 3)
+    assert.strictEqual(sorted.maintenance[0]?.subject, "chore: update dependencies")
+    assert.strictEqual(sorted.maintenance[1]?.subject, "docs: update README")
+    assert.strictEqual(sorted.maintenance[2]?.subject, "refactor - improve code structure")
 
-		assert.strictEqual(sorted.other.length, 2)
-		assert.strictEqual(sorted.other[0]?.subject, "unknown type commit")
-		assert.strictEqual(sorted.other[1]?.subject, "chore frankestein type commit")
-	})
+    assert.strictEqual(sorted.other.length, 2)
+    assert.strictEqual(sorted.other[0]?.subject, "unknown type commit")
+    assert.strictEqual(sorted.other[1]?.subject, "chore frankestein type commit")
+  })
 })

--- a/src/tests/semver.test.ts
+++ b/src/tests/semver.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert"
 import { describe, it } from "node:test"
 import { getLatestSemverTag, getNextVersion, useExistingProjectVersion } from "../lib/semver.js"
 import type { NextVersion, ProjectInfo } from "../types/semver.js"
+import type { SupportedSemverType } from "../types/tools.js"
 
 describe("getLatestSemverTag", () => {
   it("should return the latest semver tag", () => {
@@ -72,24 +73,25 @@ describe("getNextVersion", () => {
     assert.strictEqual(nextVersion.isInitialRelease, false)
   })
 
-  it("should return 1.0.0 and mark as initial release if project version is 1.0.0 and no tags exist", () => {
-    const latestTag = null
-    const projectInfo: ProjectInfo = {
-      version: "1.0.0",
-      type: "node",
-      paths: ["./package.json"]
-    }
-    const releaseType = "minor"
+  for (const releaseType of ["patch", "minor", "major"]) {
+    it(`should return 1.0.0 and mark as initial release if project version is 1.0.0 and no tags exist when releaseType is '${releaseType}'`, () => {
+      const latestTag = null
+      const projectInfo: ProjectInfo = {
+        version: "1.0.0",
+        type: "node",
+        paths: ["./package.json"]
+      }
 
-    const nextVersion: NextVersion = getNextVersion(latestTag, projectInfo, releaseType)
-    assert.strictEqual(nextVersion.version, "1.0.0")
-    assert.strictEqual(nextVersion.source, "project")
-    assert.strictEqual(nextVersion.isInitialRelease, true)
-  })
+      const nextVersion: NextVersion = getNextVersion(latestTag, projectInfo, releaseType as SupportedSemverType)
+      assert.strictEqual(nextVersion.version, "1.0.0")
+      assert.strictEqual(nextVersion.source, "project")
+      assert.strictEqual(nextVersion.isInitialRelease, true)
+    })
+  }
 })
 
 describe("useExistingProjectVersion", () => {
-  it("should return true if project version has been already been increased one time with semver type from latest tag, and we also want to increase with the same semver type", () => {
+  it("should return true if project version has already been increased one time with semver type from latest tag, and we also want to increase with the same semver type", () => {
     const patch: boolean = useExistingProjectVersion("1.2.3", "1.2.4", "patch")
     assert.strictEqual(patch, true)
     const minor: boolean = useExistingProjectVersion("1.2.3", "1.3.0", "minor")

--- a/src/tests/semver.test.ts
+++ b/src/tests/semver.test.ts
@@ -4,124 +4,124 @@ import { getLatestSemverTag, getNextVersion, useExistingProjectVersion } from ".
 import type { NextVersion, ProjectInfo } from "../types/semver.js"
 
 describe("getLatestSemverTag", () => {
-	it("should return the latest semver tag", () => {
-		// This test assumes that the git repository has at least one semver tag.
-		const latestTag: string | null = getLatestSemverTag(["v3.0.0", "v1.1.0", "v2.0.0", "v5.0.1-beta", "v6.0.0", "not-a-tag"])
-		assert.strictEqual(latestTag, "v6.0.0")
-	})
+  it("should return the latest semver tag", () => {
+    // This test assumes that the git repository has at least one semver tag.
+    const latestTag: string | null = getLatestSemverTag(["v3.0.0", "v1.1.0", "v2.0.0", "v5.0.1-beta", "v6.0.0", "not-a-tag"])
+    assert.strictEqual(latestTag, "v6.0.0")
+  })
 })
 
 describe("getNextVersion", () => {
-	it("should calculate the next version correctly if project is already increased", () => {
-		const latestTag = "1.2.3"
-		const projectInfo: ProjectInfo = {
-			version: "1.2.4",
-			type: "node",
-			paths: ["./package.json"]
-		}
-		const releaseType = "minor"
+  it("should calculate the next version correctly if project is already increased", () => {
+    const latestTag = "1.2.3"
+    const projectInfo: ProjectInfo = {
+      version: "1.2.4",
+      type: "node",
+      paths: ["./package.json"]
+    }
+    const releaseType = "minor"
 
-		const nextVersion: NextVersion = getNextVersion(latestTag, projectInfo, releaseType)
-		assert.strictEqual(nextVersion.version, "1.3.0")
-		assert.strictEqual(nextVersion.source, "tag")
-		assert.strictEqual(nextVersion.isInitialRelease, false)
-	})
+    const nextVersion: NextVersion = getNextVersion(latestTag, projectInfo, releaseType)
+    assert.strictEqual(nextVersion.version, "1.3.0")
+    assert.strictEqual(nextVersion.source, "tag")
+    assert.strictEqual(nextVersion.isInitialRelease, false)
+  })
 
-	it("should calculate the next version correctly if project is behind latest tag", () => {
-		const latestTag = "2.0.0"
-		const projectInfo: ProjectInfo = {
-			version: "1.5.0",
-			type: "node",
-			paths: ["./package.json"]
-		}
-		const releaseType = "patch"
+  it("should calculate the next version correctly if project is behind latest tag", () => {
+    const latestTag = "2.0.0"
+    const projectInfo: ProjectInfo = {
+      version: "1.5.0",
+      type: "node",
+      paths: ["./package.json"]
+    }
+    const releaseType = "patch"
 
-		const nextVersion: NextVersion = getNextVersion(latestTag, projectInfo, releaseType)
-		assert.strictEqual(nextVersion.version, "2.0.1")
-		assert.strictEqual(nextVersion.source, "tag")
-		assert.strictEqual(nextVersion.isInitialRelease, false)
-	})
+    const nextVersion: NextVersion = getNextVersion(latestTag, projectInfo, releaseType)
+    assert.strictEqual(nextVersion.version, "2.0.1")
+    assert.strictEqual(nextVersion.source, "tag")
+    assert.strictEqual(nextVersion.isInitialRelease, false)
+  })
 
-	it("should throw if no valid versions exist", () => {
-		const latestTag = null
-		const projectInfo: ProjectInfo = {
-			// @ts-expect-error Testing invalid version
-			version: null,
-			type: "node",
-			paths: ["./package.json"]
-		}
-		const releaseType = "major"
+  it("should throw if no valid versions exist", () => {
+    const latestTag = null
+    const projectInfo: ProjectInfo = {
+      // @ts-expect-error Testing invalid version
+      version: null,
+      type: "node",
+      paths: ["./package.json"]
+    }
+    const releaseType = "major"
 
-		assert.throws(() => {
-			getNextVersion(latestTag, projectInfo, releaseType)
-		}, /No valid version found/)
-	})
+    assert.throws(() => {
+      getNextVersion(latestTag, projectInfo, releaseType)
+    }, /No valid version found/)
+  })
 
-	it("should use tag if tag and project version are the same", () => {
-		const latestTag = "1.0.0"
-		const projectInfo: ProjectInfo = {
-			version: "1.0.0",
-			type: "node",
-			paths: ["./package.json"]
-		}
-		const releaseType = "minor"
+  it("should use tag if tag and project version are the same", () => {
+    const latestTag = "1.0.0"
+    const projectInfo: ProjectInfo = {
+      version: "1.0.0",
+      type: "node",
+      paths: ["./package.json"]
+    }
+    const releaseType = "minor"
 
-		const nextVersion: NextVersion = getNextVersion(latestTag, projectInfo, releaseType)
-		assert.strictEqual(nextVersion.version, "1.1.0")
-		assert.strictEqual(nextVersion.source, "tag")
-		assert.strictEqual(nextVersion.isInitialRelease, false)
-	})
+    const nextVersion: NextVersion = getNextVersion(latestTag, projectInfo, releaseType)
+    assert.strictEqual(nextVersion.version, "1.1.0")
+    assert.strictEqual(nextVersion.source, "tag")
+    assert.strictEqual(nextVersion.isInitialRelease, false)
+  })
 
-	it("should return 1.0.0 and mark as initial release if project version is 1.0.0 and no tags exist", () => {
-		const latestTag = null
-		const projectInfo: ProjectInfo = {
-			version: "1.0.0",
-			type: "node",
-			paths: ["./package.json"]
-		}
-		const releaseType = "minor"
+  it("should return 1.0.0 and mark as initial release if project version is 1.0.0 and no tags exist", () => {
+    const latestTag = null
+    const projectInfo: ProjectInfo = {
+      version: "1.0.0",
+      type: "node",
+      paths: ["./package.json"]
+    }
+    const releaseType = "minor"
 
-		const nextVersion: NextVersion = getNextVersion(latestTag, projectInfo, releaseType)
-		assert.strictEqual(nextVersion.version, "1.0.0")
-		assert.strictEqual(nextVersion.source, "project")
-		assert.strictEqual(nextVersion.isInitialRelease, true)
-	})
+    const nextVersion: NextVersion = getNextVersion(latestTag, projectInfo, releaseType)
+    assert.strictEqual(nextVersion.version, "1.0.0")
+    assert.strictEqual(nextVersion.source, "project")
+    assert.strictEqual(nextVersion.isInitialRelease, true)
+  })
 })
 
 describe("useExistingProjectVersion", () => {
-	it("should return true if project version has been already been increased one time with semver type from latest tag, and we also want to increase with the same semver type", () => {
-		const patch: boolean = useExistingProjectVersion("1.2.3", "1.2.4", "patch")
-		assert.strictEqual(patch, true)
-		const minor: boolean = useExistingProjectVersion("1.2.3", "1.3.0", "minor")
-		assert.strictEqual(minor, true)
-		const major: boolean = useExistingProjectVersion("1.2.3", "2.0.0", "major")
-		assert.strictEqual(major, true)
-	})
+  it("should return true if project version has been already been increased one time with semver type from latest tag, and we also want to increase with the same semver type", () => {
+    const patch: boolean = useExistingProjectVersion("1.2.3", "1.2.4", "patch")
+    assert.strictEqual(patch, true)
+    const minor: boolean = useExistingProjectVersion("1.2.3", "1.3.0", "minor")
+    assert.strictEqual(minor, true)
+    const major: boolean = useExistingProjectVersion("1.2.3", "2.0.0", "major")
+    assert.strictEqual(major, true)
+  })
 
-	it("should return false if project version has been increased more than one time from latest tag (someone has messed with it)", () => {
-		const result: boolean = useExistingProjectVersion("1.2.3", "1.4.1", "minor")
-		assert.strictEqual(result, false)
-	})
+  it("should return false if project version has been increased more than one time from latest tag (someone has messed with it)", () => {
+    const result: boolean = useExistingProjectVersion("1.2.3", "1.4.1", "minor")
+    assert.strictEqual(result, false)
+  })
 
-	it("should return false if project version has already been increased with patch but we want to increase with minor", () => {
-		const result: boolean = useExistingProjectVersion("1.2.3", "1.2.4", "minor")
-		assert.strictEqual(result, false)
-	})
+  it("should return false if project version has already been increased with patch but we want to increase with minor", () => {
+    const result: boolean = useExistingProjectVersion("1.2.3", "1.2.4", "minor")
+    assert.strictEqual(result, false)
+  })
 
-	it("should return false if project version is behind latest tag", () => {
-		const result: boolean = useExistingProjectVersion("2.0.0", "1.5.0", "major")
-		assert.strictEqual(result, false)
-	})
+  it("should return false if project version is behind latest tag", () => {
+    const result: boolean = useExistingProjectVersion("2.0.0", "1.5.0", "major")
+    assert.strictEqual(result, false)
+  })
 
-	it("should return false if project version is the same as latest tag", () => {
-		const result: boolean = useExistingProjectVersion("1.2.3", "1.2.3", "minor")
-		assert.strictEqual(result, false)
-	})
+  it("should return false if project version is the same as latest tag", () => {
+    const result: boolean = useExistingProjectVersion("1.2.3", "1.2.3", "minor")
+    assert.strictEqual(result, false)
+  })
 
-	it("should return false if either version is invalid", () => {
-		const result1: boolean = useExistingProjectVersion("not-a-version", "1.2.4", "patch")
-		assert.strictEqual(result1, false)
-		const result2: boolean = useExistingProjectVersion("1.2.3", "also-not-a-version", "patch")
-		assert.strictEqual(result2, false)
-	})
+  it("should return false if either version is invalid", () => {
+    const result1: boolean = useExistingProjectVersion("not-a-version", "1.2.4", "patch")
+    assert.strictEqual(result1, false)
+    const result2: boolean = useExistingProjectVersion("1.2.3", "also-not-a-version", "patch")
+    assert.strictEqual(result2, false)
+  })
 })

--- a/src/tools/nilsrelease.ts
+++ b/src/tools/nilsrelease.ts
@@ -5,6 +5,7 @@ import { generateReleaseNotes } from "../lib/release-notes.js"
 import { runTests } from "../lib/run-tests.js"
 import { getNextVersion, getProjectInfo, getSemverReleaseType, SUPPORTED_SEMVER_TYPES_BY_PRIORITY, updateProjectVersion } from "../lib/semver.js"
 import type { GitCommitType, RepoInfo } from "../types/git.js"
+import type { ProjectInfo } from "../types/semver.js"
 import type { NilsReleaseData, SupportedSemverType } from "../types/tools.js"
 
 const toolHelp = `
@@ -151,18 +152,23 @@ export const nilsrelease = (...args: string[]): void => {
 
   // If project version is different from next version, update project version
   if (releaseData.projectInfo.version !== releaseData.nextVersion.version) {
+    let newProjectInfo: ProjectInfo
     spinner = yoctoSpinner({
       text: `Updating ${releaseData.projectInfo.type}-project version in ${releaseData.projectInfo.paths.join(" and ")} to ${releaseData.nextVersion.version}...`
     }).start()
     try {
       updateProjectVersion(releaseData.projectInfo, releaseData.nextVersion.version)
+
+      newProjectInfo = getProjectInfo()
+      if (releaseData.nextVersion.version !== newProjectInfo.version) {
+        // noinspection ExceptionCaughtLocallyJS
+        throw new Error("Project version was not bumped")
+      }
     } catch (error) {
       spinner.error(`Failed to update project version: ${error instanceof Error ? error.message : String(error)}`)
       process.exit(1)
     }
-    spinner.success(
-      `${releaseData.projectInfo.type}-project version in ${releaseData.projectInfo.paths.join(" and ")} updated from ${releaseData.projectInfo.version} to ${releaseData.nextVersion.version}`
-    )
+    spinner.success(`${releaseData.projectInfo.type}-project version in ${releaseData.projectInfo.paths.join(" and ")} updated from ${releaseData.projectInfo.version} to ${newProjectInfo.version}`)
 
     spinner = yoctoSpinner({
       text: "Committing version update and pushing to remote :: "

--- a/src/tools/nilsrelease.ts
+++ b/src/tools/nilsrelease.ts
@@ -23,205 +23,205 @@ const toolHelp = `
 `
 
 export const nilsrelease = (...args: string[]): void => {
-	if (args.length === 0 || args[0] === "help" || !SUPPORTED_SEMVER_TYPES_BY_PRIORITY.includes(args[0] as SupportedSemverType)) {
-		console.log(toolHelp)
-		process.exit(1)
-	}
+  if (args.length === 0 || args[0] === "help" || !SUPPORTED_SEMVER_TYPES_BY_PRIORITY.includes(args[0] as SupportedSemverType)) {
+    console.log(toolHelp)
+    process.exit(1)
+  }
 
-	const repoInfo: RepoInfo = getRepoInfo()
-	// yocto-spinner og yocto-colors
-	let spinner: Spinner = yoctoSpinner({
-		text: "Checking if repo is clean and up-to-date..."
-	}).start()
-	try {
-		repoIsReadyForRelease(repoInfo)
-	} catch (error) {
-		spinner.error(`Repository is not ready for release: ${error instanceof Error ? error.message : String(error)}`)
-		process.exit(1)
-	}
-	spinner.success("Repository is clean and up-to-date")
+  const repoInfo: RepoInfo = getRepoInfo()
+  // yocto-spinner og yocto-colors
+  let spinner: Spinner = yoctoSpinner({
+    text: "Checking if repo is clean and up-to-date..."
+  }).start()
+  try {
+    repoIsReadyForRelease(repoInfo)
+  } catch (error) {
+    spinner.error(`Repository is not ready for release: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+  spinner.success("Repository is clean and up-to-date")
 
-	const releaseData: NilsReleaseData = {
-		semverType: args[0] as SupportedSemverType,
-		latestTag: null,
-		projectInfo: null,
-		releaseType: null,
-		nextVersion: null,
-		commits: null,
-		releaseNotes: null
-	}
+  const releaseData: NilsReleaseData = {
+    semverType: args[0] as SupportedSemverType,
+    latestTag: null,
+    projectInfo: null,
+    releaseType: null,
+    nextVersion: null,
+    commits: null,
+    releaseNotes: null
+  }
 
-	spinner = yoctoSpinner({ text: "Getting project info..." }).start()
-	try {
-		releaseData.projectInfo = getProjectInfo()
-	} catch (error) {
-		spinner.error(`Failed to get project info: ${error instanceof Error ? error.message : String(error)}`)
-		process.exit(1)
-	}
-	spinner.success(`Project version is ${releaseData.projectInfo.version} (${releaseData.projectInfo.type})`)
+  spinner = yoctoSpinner({ text: "Getting project info..." }).start()
+  try {
+    releaseData.projectInfo = getProjectInfo()
+  } catch (error) {
+    spinner.error(`Failed to get project info: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+  spinner.success(`Project version is ${releaseData.projectInfo.version} (${releaseData.projectInfo.type})`)
 
-	// Run tests before proceeding
-	spinner = yoctoSpinner({ text: "Running tests..." }).start()
-	try {
-		runTests(releaseData.projectInfo)
-	} catch (error) {
-		spinner.error(`Tests failed, please fix the errors before you create a release: ${error instanceof Error ? error.message : String(error)}`)
-		process.exit(1)
-	}
-	spinner.success("All tests passed")
+  // Run tests before proceeding
+  spinner = yoctoSpinner({ text: "Running tests..." }).start()
+  try {
+    runTests(releaseData.projectInfo)
+  } catch (error) {
+    spinner.error(`Tests failed, please fix the errors before you create a release: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+  spinner.success("All tests passed")
 
-	spinner = yoctoSpinner({ text: "Finding latest release tag..." }).start()
-	try {
-		releaseData.latestTag = getLatestReleaseTag()
-	} catch (error) {
-		spinner.error(`Failed to get latest release tag: ${error instanceof Error ? error.message : String(error)}`)
-		process.exit(1)
-	}
+  spinner = yoctoSpinner({ text: "Finding latest release tag..." }).start()
+  try {
+    releaseData.latestTag = getLatestReleaseTag()
+  } catch (error) {
+    spinner.error(`Failed to get latest release tag: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
 
-	spinner.success(releaseData.latestTag ? `Latest release tag is ${releaseData.latestTag}` : "No release tags found, will use project version")
+  spinner.success(releaseData.latestTag ? `Latest release tag is ${releaseData.latestTag}` : "No release tags found, will use project version")
 
-	// Get commits since latest release tag (and check that there are commits)
-	spinner = yoctoSpinner({ text: releaseData.latestTag ? `Getting git log commits since latest release tag ${releaseData.latestTag}` : "No latest tag found, getting all commits" }).start()
-	try {
-		releaseData.commits = getCommitsSinceTag(releaseData.latestTag)
-		if (releaseData.commits.length === 0) {
-			spinner.error(`No commits found. Why do you want to create a release with no new changes??? 🍕`)
-			process.exit(1)
-		}
+  // Get commits since latest release tag (and check that there are commits)
+  spinner = yoctoSpinner({ text: releaseData.latestTag ? `Getting git log commits since latest release tag ${releaseData.latestTag}` : "No latest tag found, getting all commits" }).start()
+  try {
+    releaseData.commits = getCommitsSinceTag(releaseData.latestTag)
+    if (releaseData.commits.length === 0) {
+      spinner.error(`No commits found. Why do you want to create a release with no new changes??? 🍕`)
+      process.exit(1)
+    }
 
-		spinner.success(`Found ${releaseData.commits.length} commit(s) since latest tag ${releaseData.latestTag}`)
+    spinner.success(`Found ${releaseData.commits.length} commit(s) since latest tag ${releaseData.latestTag}`)
 
-		spinner = yoctoSpinner({ text: "Analyzing commit types..." }).start()
-		const sortedCommits = sortCommitsByType(releaseData.commits)
-		if (!sortedCommits) {
-			spinner.error("Sorted commits is null??? Contact idiot-developers.")
-			process.exit(1)
-		}
+    spinner = yoctoSpinner({ text: "Analyzing commit types..." }).start()
+    const sortedCommits = sortCommitsByType(releaseData.commits)
+    if (!sortedCommits) {
+      spinner.error("Sorted commits is null??? Contact idiot-developers.")
+      process.exit(1)
+    }
 
-		// Determine the highest semver type present in the commits
-		const commitTypesByPriority: GitCommitType[] = [...SUPPORTED_SEMVER_TYPES_BY_PRIORITY, "maintenance", "other"]
+    // Determine the highest semver type present in the commits
+    const commitTypesByPriority: GitCommitType[] = [...SUPPORTED_SEMVER_TYPES_BY_PRIORITY, "maintenance", "other"]
 
-		const highestCommitType: GitCommitType | undefined = commitTypesByPriority.find((type: GitCommitType) => sortedCommits?.[type] && sortedCommits[type].length > 0)
-		if (!highestCommitType) {
-			spinner.error("No commit types found. Probably no commits at all, but we already checked that??? Contact idiot-developers.")
-			process.exit(1)
-		}
+    const highestCommitType: GitCommitType | undefined = commitTypesByPriority.find((type: GitCommitType) => sortedCommits?.[type] && sortedCommits[type].length > 0)
+    if (!highestCommitType) {
+      spinner.error("No commit types found. Probably no commits at all, but we already checked that??? Contact idiot-developers.")
+      process.exit(1)
+    }
 
-		const requestedTypeIndex: number = commitTypesByPriority.indexOf(releaseData.semverType) // Lower index means higher priority
-		const highestTypeIndex: number = commitTypesByPriority.indexOf(highestCommitType)
-		if (highestTypeIndex < requestedTypeIndex) {
-			spinner.error(
-				`The requested PR type "${releaseData.semverType}" is lower than the highest commit type "${highestCommitType}" in the branch. Please review your commits and choose a higher PR type.`
-			)
-			// List the commits beautifully-ish in the terminal
-			console.log(`Commits by type:`)
-			for (const type of commitTypesByPriority) {
-				if (sortedCommits?.[type] && sortedCommits[type].length > 0) {
-					console.log(`\n${type.toUpperCase()} COMMITS:`)
-					for (const commit of sortedCommits[type]) {
-						console.log(`- ${commit.subject} (${commit.hash})`)
-					}
-				}
-			}
-			process.exit(1)
-		}
+    const requestedTypeIndex: number = commitTypesByPriority.indexOf(releaseData.semverType) // Lower index means higher priority
+    const highestTypeIndex: number = commitTypesByPriority.indexOf(highestCommitType)
+    if (highestTypeIndex < requestedTypeIndex) {
+      spinner.error(
+        `The requested PR type "${releaseData.semverType}" is lower than the highest commit type "${highestCommitType}" in the branch. Please review your commits and choose a higher PR type.`
+      )
+      // List the commits beautifully-ish in the terminal
+      console.log(`Commits by type:`)
+      for (const type of commitTypesByPriority) {
+        if (sortedCommits?.[type] && sortedCommits[type].length > 0) {
+          console.log(`\n${type.toUpperCase()} COMMITS:`)
+          for (const commit of sortedCommits[type]) {
+            console.log(`- ${commit.subject} (${commit.hash})`)
+          }
+        }
+      }
+      process.exit(1)
+    }
 
-		// Check if there are commits that do not follow conventional commit types
-		if (sortedCommits.other.length > 0) {
-			yoctoSpinner().start().warning(`There are ${sortedCommits.other.length} commit(s) of type "other". Remember to prefix with conventional commit types for proper versioning.`)
-			// List out conventional commit types
-			console.log(`\t - Conventional commit types (suffix the type with : or - ) are: ${Object.values(conventionalCommitTypes).flat().join(", ")}`)
-		}
-	} catch (error) {
-		spinner.error(`Failed to get commits: ${error instanceof Error ? error.message : String(error)}`)
-		process.exit(1)
-	}
+    // Check if there are commits that do not follow conventional commit types
+    if (sortedCommits.other.length > 0) {
+      yoctoSpinner().start().warning(`There are ${sortedCommits.other.length} commit(s) of type "other". Remember to prefix with conventional commit types for proper versioning.`)
+      // List out conventional commit types
+      console.log(`\t - Conventional commit types (suffix the type with : or - ) are: ${Object.values(conventionalCommitTypes).flat().join(", ")}`)
+    }
+  } catch (error) {
+    spinner.error(`Failed to get commits: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
 
-	spinner.success(`Commits validated for release type "${releaseData.semverType}"`)
+  spinner.success(`Commits validated for release type "${releaseData.semverType}"`)
 
-	// Check if we need to update project version based on latest tag and release type, and do it if needed
-	spinner = yoctoSpinner({ text: "Determining next version..." }).start()
-	try {
-		releaseData.nextVersion = getNextVersion(releaseData.latestTag, releaseData.projectInfo, releaseData.semverType)
-	} catch (error) {
-		spinner.error(`Failed to determine next version: ${error instanceof Error ? error.message : String(error)}`)
-		process.exit(1)
-	}
-	spinner.success(`Next version is ${releaseData.nextVersion.version} (${releaseData.nextVersion.description})${releaseData.nextVersion.isInitialRelease ? ", this is the initial release" : ""}`)
+  // Check if we need to update project version based on latest tag and release type, and do it if needed
+  spinner = yoctoSpinner({ text: "Determining next version..." }).start()
+  try {
+    releaseData.nextVersion = getNextVersion(releaseData.latestTag, releaseData.projectInfo, releaseData.semverType)
+  } catch (error) {
+    spinner.error(`Failed to determine next version: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+  spinner.success(`Next version is ${releaseData.nextVersion.version} (${releaseData.nextVersion.description})${releaseData.nextVersion.isInitialRelease ? ", this is the initial release" : ""}`)
 
-	// If project version is different from next version, update project version
-	if (releaseData.projectInfo.version !== releaseData.nextVersion.version) {
-		spinner = yoctoSpinner({
-			text: `Updating ${releaseData.projectInfo.type}-project version in ${releaseData.projectInfo.paths.join(" and ")} to ${releaseData.nextVersion.version}...`
-		}).start()
-		try {
-			updateProjectVersion(releaseData.projectInfo, releaseData.nextVersion.version)
-		} catch (error) {
-			spinner.error(`Failed to update project version: ${error instanceof Error ? error.message : String(error)}`)
-			process.exit(1)
-		}
-		spinner.success(
-			`${releaseData.projectInfo.type}-project version in ${releaseData.projectInfo.paths.join(" and ")} updated from ${releaseData.projectInfo.version} to ${releaseData.nextVersion.version}`
-		)
+  // If project version is different from next version, update project version
+  if (releaseData.projectInfo.version !== releaseData.nextVersion.version) {
+    spinner = yoctoSpinner({
+      text: `Updating ${releaseData.projectInfo.type}-project version in ${releaseData.projectInfo.paths.join(" and ")} to ${releaseData.nextVersion.version}...`
+    }).start()
+    try {
+      updateProjectVersion(releaseData.projectInfo, releaseData.nextVersion.version)
+    } catch (error) {
+      spinner.error(`Failed to update project version: ${error instanceof Error ? error.message : String(error)}`)
+      process.exit(1)
+    }
+    spinner.success(
+      `${releaseData.projectInfo.type}-project version in ${releaseData.projectInfo.paths.join(" and ")} updated from ${releaseData.projectInfo.version} to ${releaseData.nextVersion.version}`
+    )
 
-		spinner = yoctoSpinner({
-			text: "Committing version update and pushing to remote :: "
-		}).start()
-		try {
-			// Commit and push changes
-			commitAndPush(`chore: bump version to ${releaseData.nextVersion.version}`)
-		} catch (error) {
-			spinner.error(`Failed to commit and push changes: ${error instanceof Error ? error.message : String(error)}`)
-			process.exit(1)
-		}
+    spinner = yoctoSpinner({
+      text: "Committing version update and pushing to remote :: "
+    }).start()
+    try {
+      // Commit and push changes
+      commitAndPush(`chore: bump version to ${releaseData.nextVersion.version}`)
+    } catch (error) {
+      spinner.error(`Failed to commit and push changes: ${error instanceof Error ? error.message : String(error)}`)
+      process.exit(1)
+    }
 
-		// Update current project version to match what we just updated/confirmed, to make sure that the correct version is used when generating release notes and the release link
-		releaseData.projectInfo.version = releaseData.nextVersion.version
+    // Update current project version to match what we just updated/confirmed, to make sure that the correct version is used when generating release notes and the release link
+    releaseData.projectInfo.version = releaseData.nextVersion.version
 
-		// Push the latest commit to releaseData.commits so that the release notes include the commit that bumps the version
-		if (!releaseData.commits) {
-			spinner.error("Release data commits is null??? Contact idiot-developers.")
-			process.exit(1)
-		}
-		const versionBumpCommit = getCommitsSinceTag(releaseData.commits[0]?.hash)[0] // Get the latest commit, which should be the version bump commit we just made
-		if (!versionBumpCommit) {
-			spinner.error("Could not find version bump commit in git log??? Contact idiot-developers.")
-			process.exit(1)
-		}
-		releaseData.commits.unshift(versionBumpCommit)
+    // Push the latest commit to releaseData.commits so that the release notes include the commit that bumps the version
+    if (!releaseData.commits) {
+      spinner.error("Release data commits is null??? Contact idiot-developers.")
+      process.exit(1)
+    }
+    const versionBumpCommit = getCommitsSinceTag(releaseData.commits[0]?.hash)[0] // Get the latest commit, which should be the version bump commit we just made
+    if (!versionBumpCommit) {
+      spinner.error("Could not find version bump commit in git log??? Contact idiot-developers.")
+      process.exit(1)
+    }
+    releaseData.commits.unshift(versionBumpCommit)
 
-		spinner.success("Version update committed and pushed to remote, local project version updated to match the new version, and version bump commit added to release data commits")
-	} else {
-		spinner = yoctoSpinner({
-			text: `${releaseData.projectInfo.type}-project version in ${releaseData.projectInfo.paths.join(" and ")} is already up to date.`
-		})
-		spinner.start()
-		spinner.success()
-	}
+    spinner.success("Version update committed and pushed to remote, local project version updated to match the new version, and version bump commit added to release data commits")
+  } else {
+    spinner = yoctoSpinner({
+      text: `${releaseData.projectInfo.type}-project version in ${releaseData.projectInfo.paths.join(" and ")} is already up to date.`
+    })
+    spinner.start()
+    spinner.success()
+  }
 
-	// Finn ut av hva slags semver type release vi skal lage basert på latestTag og project version
-	spinner = yoctoSpinner({ text: "Determining release type (semver) based on latest release tag and next project version..." }).start()
-	try {
-		releaseData.releaseType = getSemverReleaseType(releaseData.latestTag, releaseData.projectInfo)
-	} catch (error) {
-		spinner.error(`Failed to determine semver type: ${error instanceof Error ? error.message : String(error)}`)
-		process.exit(1)
-	}
-	spinner.success(`Determined release type (semver) is ${releaseData.releaseType}. Release-tag will be ${releaseData.nextVersion.version}`)
+  // Finn ut av hva slags semver type release vi skal lage basert på latestTag og project version
+  spinner = yoctoSpinner({ text: "Determining release type (semver) based on latest release tag and next project version..." }).start()
+  try {
+    releaseData.releaseType = getSemverReleaseType(releaseData.latestTag, releaseData.projectInfo)
+  } catch (error) {
+    spinner.error(`Failed to determine semver type: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+  spinner.success(`Determined release type (semver) is ${releaseData.releaseType}. Release-tag will be ${releaseData.nextVersion.version}`)
 
-	try {
-		releaseData.releaseNotes = generateReleaseNotes(releaseData)
-	} catch (error) {
-		spinner.error(`Failed to generate release notes: ${error instanceof Error ? error.message : String(error)}`)
-		process.exit(1)
-	}
-	spinner.success("Release notes generated")
+  try {
+    releaseData.releaseNotes = generateReleaseNotes(releaseData)
+  } catch (error) {
+    spinner.error(`Failed to generate release notes: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+  spinner.success("Release notes generated")
 
-	// Then we create a PR from a query link to GitHub with the right info filled in
-	const releaseTitle = `Release ${releaseData.nextVersion.version}`
-	const releaseBody: string = releaseData.releaseNotes
+  // Then we create a PR from a query link to GitHub with the right info filled in
+  const releaseTitle = `Release ${releaseData.nextVersion.version}`
+  const releaseBody: string = releaseData.releaseNotes
 
-	const releaseLink = `${repoInfo.githubUrl}/releases/new?tag=${encodeURIComponent(releaseData.nextVersion.version)}&title=${encodeURIComponent(releaseTitle)}&body=${encodeURIComponent(releaseBody)}`
+  const releaseLink = `${repoInfo.githubUrl}/releases/new?tag=${encodeURIComponent(releaseData.nextVersion.version)}&title=${encodeURIComponent(releaseTitle)}&body=${encodeURIComponent(releaseBody)}`
 
-	openUrl(releaseLink, "🚀 Create your release here if it did not open automatically")
+  openUrl(releaseLink, "🚀 Create your release here if it did not open automatically")
 }

--- a/src/tools/pr.ts
+++ b/src/tools/pr.ts
@@ -22,190 +22,190 @@ const toolHelp = `
 `
 
 export const pr = (...args: string[]): void => {
-	if (args.length === 0 || args[0] === "help" || !SUPPORTED_SEMVER_TYPES_BY_PRIORITY.includes(args[0] as SupportedSemverType)) {
-		console.log(toolHelp)
-		process.exit(1)
-	}
+  if (args.length === 0 || args[0] === "help" || !SUPPORTED_SEMVER_TYPES_BY_PRIORITY.includes(args[0] as SupportedSemverType)) {
+    console.log(toolHelp)
+    process.exit(1)
+  }
 
-	const repoInfo: RepoInfo = getRepoInfo()
+  const repoInfo: RepoInfo = getRepoInfo()
 
-	// yocto-spinner og yocto-colors
-	let spinner: Spinner = yoctoSpinner({
-		text: "Checking if repo is clean and up-to-date..."
-	}).start()
-	try {
-		repoIsReadyForPullRequest(repoInfo)
-	} catch (error) {
-		spinner.error(`Repository is not ready for PR: ${error instanceof Error ? error.message : String(error)}`)
-		process.exit(1)
-	}
-	spinner.success("Repository is clean and up-to-date")
+  // yocto-spinner og yocto-colors
+  let spinner: Spinner = yoctoSpinner({
+    text: "Checking if repo is clean and up-to-date..."
+  }).start()
+  try {
+    repoIsReadyForPullRequest(repoInfo)
+  } catch (error) {
+    spinner.error(`Repository is not ready for PR: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+  spinner.success("Repository is clean and up-to-date")
 
-	const pullRequestData: PullRequestData = {
-		semverType: args[0] as SupportedSemverType,
-		latestTag: null,
-		projectInfo: null,
-		nextVersion: null,
-		sortedCommits: null
-	}
+  const pullRequestData: PullRequestData = {
+    semverType: args[0] as SupportedSemverType,
+    latestTag: null,
+    projectInfo: null,
+    nextVersion: null,
+    sortedCommits: null
+  }
 
-	spinner = yoctoSpinner({ text: "Getting project info..." }).start()
-	try {
-		pullRequestData.projectInfo = getProjectInfo()
-	} catch (error) {
-		const errorMessage: string = error instanceof Error ? error.message : String(error)
-		spinner.error(`Failed to get project info: ${errorMessage}`)
-		process.exit(1)
-	}
-	if (!pullRequestData.projectInfo) {
-		spinner.error("Project info is null??? Contact idiot-developers.")
-		process.exit(1)
-	}
-	spinner.success(`Project version is ${pullRequestData.projectInfo.version} (${pullRequestData.projectInfo.type})`)
+  spinner = yoctoSpinner({ text: "Getting project info..." }).start()
+  try {
+    pullRequestData.projectInfo = getProjectInfo()
+  } catch (error) {
+    const errorMessage: string = error instanceof Error ? error.message : String(error)
+    spinner.error(`Failed to get project info: ${errorMessage}`)
+    process.exit(1)
+  }
+  if (!pullRequestData.projectInfo) {
+    spinner.error("Project info is null??? Contact idiot-developers.")
+    process.exit(1)
+  }
+  spinner.success(`Project version is ${pullRequestData.projectInfo.version} (${pullRequestData.projectInfo.type})`)
 
-	// Run tests before proceeding
-	spinner = yoctoSpinner({ text: "Running tests..." }).start()
-	try {
-		runTests(pullRequestData.projectInfo)
-	} catch (error) {
-		const errorMessage = error instanceof Error ? error.message : String(error)
-		spinner.error(`Tests failed, please fix the errors before you create a PR: ${errorMessage}`)
-		process.exit(1)
-	}
-	spinner.success("All tests passed")
+  // Run tests before proceeding
+  spinner = yoctoSpinner({ text: "Running tests..." }).start()
+  try {
+    runTests(pullRequestData.projectInfo)
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error)
+    spinner.error(`Tests failed, please fix the errors before you create a PR: ${errorMessage}`)
+    process.exit(1)
+  }
+  spinner.success("All tests passed")
 
-	// Get commits in current branch not in main/default branch - check that there are commits, and if semverType is present, check that it is not lower than the commit types
-	spinner = yoctoSpinner({ text: `Getting commits in branch ${repoInfo.currentBranch} not in ${repoInfo.defaultBranch}...` }).start()
-	try {
-		const commitsInCurrentBranch: GitLogCommit[] = getBranchSpecificCommits(repoInfo.currentBranch)
-		if (commitsInCurrentBranch.length === 0) {
-			spinner.error(`No commits found in branch ${repoInfo.currentBranch} that are not in ${repoInfo.defaultBranch}. Why do you want to create a PR with no new changes??? 🍕`)
-			process.exit(1)
-		}
-		spinner.success(`Found ${commitsInCurrentBranch.length} commits in branch ${repoInfo.currentBranch} not in ${repoInfo.defaultBranch}`)
+  // Get commits in current branch not in main/default branch - check that there are commits, and if semverType is present, check that it is not lower than the commit types
+  spinner = yoctoSpinner({ text: `Getting commits in branch ${repoInfo.currentBranch} not in ${repoInfo.defaultBranch}...` }).start()
+  try {
+    const commitsInCurrentBranch: GitLogCommit[] = getBranchSpecificCommits(repoInfo.currentBranch)
+    if (commitsInCurrentBranch.length === 0) {
+      spinner.error(`No commits found in branch ${repoInfo.currentBranch} that are not in ${repoInfo.defaultBranch}. Why do you want to create a PR with no new changes??? 🍕`)
+      process.exit(1)
+    }
+    spinner.success(`Found ${commitsInCurrentBranch.length} commits in branch ${repoInfo.currentBranch} not in ${repoInfo.defaultBranch}`)
 
-		spinner = yoctoSpinner({ text: "Analyzing commit types..." }).start()
-		pullRequestData.sortedCommits = sortCommitsByType(commitsInCurrentBranch)
-		if (!pullRequestData.sortedCommits) {
-			spinner.error("Sorted commits is null??? Contact idiot-developers.")
-			process.exit(1)
-		}
+    spinner = yoctoSpinner({ text: "Analyzing commit types..." }).start()
+    pullRequestData.sortedCommits = sortCommitsByType(commitsInCurrentBranch)
+    if (!pullRequestData.sortedCommits) {
+      spinner.error("Sorted commits is null??? Contact idiot-developers.")
+      process.exit(1)
+    }
 
-		// Determine the highest semver type present in the commits
-		const commitTypesByPriority: GitCommitType[] = [...SUPPORTED_SEMVER_TYPES_BY_PRIORITY, "maintenance", "other"]
+    // Determine the highest semver type present in the commits
+    const commitTypesByPriority: GitCommitType[] = [...SUPPORTED_SEMVER_TYPES_BY_PRIORITY, "maintenance", "other"]
 
-		const highestCommitType: GitCommitType | undefined = commitTypesByPriority.find((type: GitCommitType) => pullRequestData.sortedCommits?.[type] && pullRequestData.sortedCommits[type].length > 0)
-		if (!highestCommitType) {
-			spinner.error("No commit types found. Probably no commits at all, but we already checked that??? Contact idiot-developers.")
-			process.exit(1)
-		}
+    const highestCommitType: GitCommitType | undefined = commitTypesByPriority.find((type: GitCommitType) => pullRequestData.sortedCommits?.[type] && pullRequestData.sortedCommits[type].length > 0)
+    if (!highestCommitType) {
+      spinner.error("No commit types found. Probably no commits at all, but we already checked that??? Contact idiot-developers.")
+      process.exit(1)
+    }
 
-		const requestedTypeIndex: number = commitTypesByPriority.indexOf(pullRequestData.semverType) // Lower index means higher priority
-		const highestTypeIndex: number = commitTypesByPriority.indexOf(highestCommitType)
-		if (highestTypeIndex < requestedTypeIndex) {
-			spinner.error(
-				`The requested PR type "${pullRequestData.semverType}" is lower than the highest commit type "${highestCommitType}" in the branch. Please review your commits and choose a higher PR type.`
-			)
-			// List the commits beautifully-ish in the terminal
-			console.log(`Commits by type:`)
-			for (const type of commitTypesByPriority) {
-				if (pullRequestData.sortedCommits?.[type] && pullRequestData.sortedCommits[type].length > 0) {
-					console.log(`\n${type.toUpperCase()} COMMITS:`)
-					for (const commit of pullRequestData.sortedCommits[type]) {
-						console.log(`- ${commit.subject} (${commit.hash})`)
-					}
-				}
-			}
-			process.exit(1)
-		}
-		// Check if there are commits that do not follow conventional commit types
-		if (pullRequestData.sortedCommits.other.length > 0) {
-			yoctoSpinner().start().warning(`There are ${pullRequestData.sortedCommits.other.length} commit(s) of type "other". Remember to prefix with conventional commit types for proper versioning.`)
-			// List out conventional commit types
-			console.log(`\t - Conventional commit types (suffix the type with : or - ) are: ${Object.values(conventionalCommitTypes).flat().join(", ")}`)
-		}
-	} catch (error) {
-		spinner.error(`Failed to get commits: ${error instanceof Error ? error.message : String(error)}`)
-		process.exit(1)
-	}
-	spinner.success(`Commits validated for PR type "${pullRequestData.semverType}"`)
+    const requestedTypeIndex: number = commitTypesByPriority.indexOf(pullRequestData.semverType) // Lower index means higher priority
+    const highestTypeIndex: number = commitTypesByPriority.indexOf(highestCommitType)
+    if (highestTypeIndex < requestedTypeIndex) {
+      spinner.error(
+        `The requested PR type "${pullRequestData.semverType}" is lower than the highest commit type "${highestCommitType}" in the branch. Please review your commits and choose a higher PR type.`
+      )
+      // List the commits beautifully-ish in the terminal
+      console.log(`Commits by type:`)
+      for (const type of commitTypesByPriority) {
+        if (pullRequestData.sortedCommits?.[type] && pullRequestData.sortedCommits[type].length > 0) {
+          console.log(`\n${type.toUpperCase()} COMMITS:`)
+          for (const commit of pullRequestData.sortedCommits[type]) {
+            console.log(`- ${commit.subject} (${commit.hash})`)
+          }
+        }
+      }
+      process.exit(1)
+    }
+    // Check if there are commits that do not follow conventional commit types
+    if (pullRequestData.sortedCommits.other.length > 0) {
+      yoctoSpinner().start().warning(`There are ${pullRequestData.sortedCommits.other.length} commit(s) of type "other". Remember to prefix with conventional commit types for proper versioning.`)
+      // List out conventional commit types
+      console.log(`\t - Conventional commit types (suffix the type with : or - ) are: ${Object.values(conventionalCommitTypes).flat().join(", ")}`)
+    }
+  } catch (error) {
+    spinner.error(`Failed to get commits: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+  spinner.success(`Commits validated for PR type "${pullRequestData.semverType}"`)
 
-	spinner = yoctoSpinner({ text: "Finding latest release tag..." }).start()
-	try {
-		pullRequestData.latestTag = getLatestReleaseTag()
-	} catch (error) {
-		spinner.error(`Failed to get latest release tag: ${error instanceof Error ? error.message : String(error)}`)
-		process.exit(1)
-	}
-	spinner.success(pullRequestData.latestTag ? `Latest release tag is ${pullRequestData.latestTag}` : "No release tags found, will use project version or start from 1.0.0")
+  spinner = yoctoSpinner({ text: "Finding latest release tag..." }).start()
+  try {
+    pullRequestData.latestTag = getLatestReleaseTag()
+  } catch (error) {
+    spinner.error(`Failed to get latest release tag: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+  spinner.success(pullRequestData.latestTag ? `Latest release tag is ${pullRequestData.latestTag}` : "No release tags found, will use project version or start from 1.0.0")
 
-	spinner = yoctoSpinner({ text: "Determining next version..." }).start()
-	try {
-		pullRequestData.nextVersion = getNextVersion(pullRequestData.latestTag, pullRequestData.projectInfo, pullRequestData.semverType)
-	} catch (error) {
-		spinner.error(`Failed to determine next version: ${error instanceof Error ? error.message : String(error)}`)
-		process.exit(1)
-	}
-	spinner.success(
-		`Next version is ${pullRequestData.nextVersion.version} (${pullRequestData.nextVersion.description})${pullRequestData.nextVersion.isInitialRelease ? ", this is the initial release" : ""}`
-	)
+  spinner = yoctoSpinner({ text: "Determining next version..." }).start()
+  try {
+    pullRequestData.nextVersion = getNextVersion(pullRequestData.latestTag, pullRequestData.projectInfo, pullRequestData.semverType)
+  } catch (error) {
+    spinner.error(`Failed to determine next version: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+  spinner.success(
+    `Next version is ${pullRequestData.nextVersion.version} (${pullRequestData.nextVersion.description})${pullRequestData.nextVersion.isInitialRelease ? ", this is the initial release" : ""}`
+  )
 
-	// If project version is different from next version, update project version
-	if (pullRequestData.projectInfo.version !== pullRequestData.nextVersion.version) {
-		spinner = yoctoSpinner({
-			text: `Updating ${pullRequestData.projectInfo.type}-project version in ${pullRequestData.projectInfo.paths.join(" and ")} to ${pullRequestData.nextVersion.version}...`
-		}).start()
-		try {
-			updateProjectVersion(pullRequestData.projectInfo, pullRequestData.nextVersion.version)
-		} catch (error) {
-			spinner.error(`Failed to update project version: ${error instanceof Error ? error.message : String(error)}`)
-			process.exit(1)
-		}
-		spinner.success(
-			`${pullRequestData.projectInfo.type}-project version in ${pullRequestData.projectInfo.paths.join(" and ")} updated from ${pullRequestData.projectInfo.version} to ${pullRequestData.nextVersion.version}`
-		)
+  // If project version is different from next version, update project version
+  if (pullRequestData.projectInfo.version !== pullRequestData.nextVersion.version) {
+    spinner = yoctoSpinner({
+      text: `Updating ${pullRequestData.projectInfo.type}-project version in ${pullRequestData.projectInfo.paths.join(" and ")} to ${pullRequestData.nextVersion.version}...`
+    }).start()
+    try {
+      updateProjectVersion(pullRequestData.projectInfo, pullRequestData.nextVersion.version)
+    } catch (error) {
+      spinner.error(`Failed to update project version: ${error instanceof Error ? error.message : String(error)}`)
+      process.exit(1)
+    }
+    spinner.success(
+      `${pullRequestData.projectInfo.type}-project version in ${pullRequestData.projectInfo.paths.join(" and ")} updated from ${pullRequestData.projectInfo.version} to ${pullRequestData.nextVersion.version}`
+    )
 
-		spinner = yoctoSpinner({
-			text: "Committing version update and pushing to remote :: "
-		}).start()
-		try {
-			// Commit and push changes
-			commitAndPush(`chore: bump version to ${pullRequestData.nextVersion.version}`)
-		} catch (error) {
-			spinner.error(`Failed to commit and push changes: ${error instanceof Error ? error.message : String(error)}`)
-			process.exit(1)
-		}
-		spinner.success("Version update committed and pushed to remote")
-	} else {
-		spinner = yoctoSpinner({
-			text: `${pullRequestData.projectInfo.type}-project version in ${pullRequestData.projectInfo.paths.join(" and ")} is already up to date.`
-		})
-		spinner.start()
-		spinner.success()
-	}
+    spinner = yoctoSpinner({
+      text: "Committing version update and pushing to remote :: "
+    }).start()
+    try {
+      // Commit and push changes
+      commitAndPush(`chore: bump version to ${pullRequestData.nextVersion.version}`)
+    } catch (error) {
+      spinner.error(`Failed to commit and push changes: ${error instanceof Error ? error.message : String(error)}`)
+      process.exit(1)
+    }
+    spinner.success("Version update committed and pushed to remote")
+  } else {
+    spinner = yoctoSpinner({
+      text: `${pullRequestData.projectInfo.type}-project version in ${pullRequestData.projectInfo.paths.join(" and ")} is already up to date.`
+    })
+    spinner.start()
+    spinner.success()
+  }
 
-	if (!repoInfo.githubUsername) {
-		yoctoSpinner({
-			text: "Consider adding 'github.user' to your git config to allow setting your GitHub user as assignee to the PR's you create. Run: 'git config --global github.user %replace-with-your-github-username%'"
-		})
-			.start()
-			.warning()
-	}
+  if (!repoInfo.githubUsername) {
+    yoctoSpinner({
+      text: "Consider adding 'github.user' to your git config to allow setting your GitHub user as assignee to the PR's you create. Run: 'git config --global github.user %replace-with-your-github-username%'"
+    })
+      .start()
+      .warning()
+  }
 
-	// Then we create a PR from a query link to GitHub with the right info filled in
-	const prTitle = `${pullRequestData.semverType}: ${pullRequestData.nextVersion.version} - ${repoInfo.currentBranch}`
-	// Create PR body based on all the commits in the branch
-	let prBody: string = ""
-	for (const [type, commits] of Object.entries(pullRequestData.sortedCommits)) {
-		if (commits && commits.length > 0) {
-			prBody += `\n### ${type.charAt(0).toUpperCase() + type.slice(1)} commits:\n`
-			for (const commit of commits) {
-				prBody += `- ${commit.subject} (${commit.hash})\n`
-			}
-		}
-	}
+  // Then we create a PR from a query link to GitHub with the right info filled in
+  const prTitle = `${pullRequestData.semverType}: ${pullRequestData.nextVersion.version} - ${repoInfo.currentBranch}`
+  // Create PR body based on all the commits in the branch
+  let prBody: string = ""
+  for (const [type, commits] of Object.entries(pullRequestData.sortedCommits)) {
+    if (commits && commits.length > 0) {
+      prBody += `\n### ${type.charAt(0).toUpperCase() + type.slice(1)} commits:\n`
+      for (const commit of commits) {
+        prBody += `- ${commit.subject} (${commit.hash})\n`
+      }
+    }
+  }
 
-	const assignee: string = repoInfo.githubUsername ? `&assignees=${encodeURIComponent(repoInfo.githubUsername)}` : ""
-	const prLink = `${repoInfo.githubUrl}/compare/${repoInfo.defaultBranch}...${encodeURIComponent(repoInfo.currentBranch)}?quick_pull=1&title=${encodeURIComponent(prTitle)}&body=${encodeURIComponent(prBody)}${assignee}`
-	openUrl(prLink, "🪾 Create your PR here if it did not open automatically")
+  const assignee: string = repoInfo.githubUsername ? `&assignees=${encodeURIComponent(repoInfo.githubUsername)}` : ""
+  const prLink = `${repoInfo.githubUrl}/compare/${repoInfo.defaultBranch}...${encodeURIComponent(repoInfo.currentBranch)}?quick_pull=1&title=${encodeURIComponent(prTitle)}&body=${encodeURIComponent(prBody)}${assignee}`
+  openUrl(prLink, "🪾 Create your PR here if it did not open automatically")
 }

--- a/src/tools/pr.ts
+++ b/src/tools/pr.ts
@@ -4,6 +4,7 @@ import { openUrl } from "../lib/open-url.js"
 import { runTests } from "../lib/run-tests.js"
 import { getNextVersion, getProjectInfo, SUPPORTED_SEMVER_TYPES_BY_PRIORITY, updateProjectVersion } from "../lib/semver.js"
 import type { GitCommitType, GitLogCommit, RepoInfo } from "../types/git.js"
+import type { ProjectInfo } from "../types/semver.js"
 import type { PullRequestData, SupportedSemverType } from "../types/tools.js"
 
 const toolHelp = `
@@ -152,17 +153,24 @@ export const pr = (...args: string[]): void => {
 
   // If project version is different from next version, update project version
   if (pullRequestData.projectInfo.version !== pullRequestData.nextVersion.version) {
+    let newProjectInfo: ProjectInfo
     spinner = yoctoSpinner({
       text: `Updating ${pullRequestData.projectInfo.type}-project version in ${pullRequestData.projectInfo.paths.join(" and ")} to ${pullRequestData.nextVersion.version}...`
     }).start()
     try {
       updateProjectVersion(pullRequestData.projectInfo, pullRequestData.nextVersion.version)
+
+      newProjectInfo = getProjectInfo()
+      if (pullRequestData.nextVersion.version !== newProjectInfo.version) {
+        // noinspection ExceptionCaughtLocallyJS
+        throw new Error("Project version was not bumped")
+      }
     } catch (error) {
       spinner.error(`Failed to update project version: ${error instanceof Error ? error.message : String(error)}`)
       process.exit(1)
     }
     spinner.success(
-      `${pullRequestData.projectInfo.type}-project version in ${pullRequestData.projectInfo.paths.join(" and ")} updated from ${pullRequestData.projectInfo.version} to ${pullRequestData.nextVersion.version}`
+      `${pullRequestData.projectInfo.type}-project version in ${pullRequestData.projectInfo.paths.join(" and ")} updated from ${pullRequestData.projectInfo.version} to ${newProjectInfo.version}`
     )
 
     spinner = yoctoSpinner({

--- a/src/tools/release.ts
+++ b/src/tools/release.ts
@@ -21,98 +21,98 @@ const toolHelp = `
 `
 
 export const release = (...args: string[]): void => {
-	if (args[0] === "help") {
-		console.log(toolHelp)
-		process.exit(1)
-	}
+  if (args[0] === "help") {
+    console.log(toolHelp)
+    process.exit(1)
+  }
 
-	const repoInfo: RepoInfo = getRepoInfo()
-	// yocto-spinner og yocto-colors
-	let spinner: Spinner = yoctoSpinner({
-		text: "Checking if repo is clean and up-to-date..."
-	}).start()
-	try {
-		repoIsReadyForRelease(repoInfo)
-	} catch (error) {
-		spinner.error(`Repository is not ready for release: ${error instanceof Error ? error.message : String(error)}`)
-		process.exit(1)
-	}
-	spinner.success("Repository is clean and up-to-date")
+  const repoInfo: RepoInfo = getRepoInfo()
+  // yocto-spinner og yocto-colors
+  let spinner: Spinner = yoctoSpinner({
+    text: "Checking if repo is clean and up-to-date..."
+  }).start()
+  try {
+    repoIsReadyForRelease(repoInfo)
+  } catch (error) {
+    spinner.error(`Repository is not ready for release: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+  spinner.success("Repository is clean and up-to-date")
 
-	const releaseData: ReleaseData = {
-		latestTag: null,
-		projectInfo: null,
-		releaseType: null,
-		commits: null,
-		releaseNotes: null
-	}
+  const releaseData: ReleaseData = {
+    latestTag: null,
+    projectInfo: null,
+    releaseType: null,
+    commits: null,
+    releaseNotes: null
+  }
 
-	spinner = yoctoSpinner({ text: "Getting project info..." }).start()
-	try {
-		releaseData.projectInfo = getProjectInfo()
-	} catch (error) {
-		spinner.error(`Failed to get project info: ${error instanceof Error ? error.message : String(error)}`)
-		process.exit(1)
-	}
-	spinner.success(`Project version is ${releaseData.projectInfo.version} (${releaseData.projectInfo.type})`)
+  spinner = yoctoSpinner({ text: "Getting project info..." }).start()
+  try {
+    releaseData.projectInfo = getProjectInfo()
+  } catch (error) {
+    spinner.error(`Failed to get project info: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+  spinner.success(`Project version is ${releaseData.projectInfo.version} (${releaseData.projectInfo.type})`)
 
-	// Run tests before proceeding
-	spinner = yoctoSpinner({ text: "Running tests..." }).start()
-	try {
-		runTests(releaseData.projectInfo)
-	} catch (error) {
-		spinner.error(`Tests failed, please fix the errors before you create a release: ${error instanceof Error ? error.message : String(error)}`)
-		process.exit(1)
-	}
-	spinner.success("All tests passed")
+  // Run tests before proceeding
+  spinner = yoctoSpinner({ text: "Running tests..." }).start()
+  try {
+    runTests(releaseData.projectInfo)
+  } catch (error) {
+    spinner.error(`Tests failed, please fix the errors before you create a release: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+  spinner.success("All tests passed")
 
-	spinner = yoctoSpinner({ text: "Finding latest release tag..." }).start()
-	try {
-		releaseData.latestTag = getLatestReleaseTag()
-	} catch (error) {
-		spinner.error(`Failed to get latest release tag: ${error instanceof Error ? error.message : String(error)}`)
-		process.exit(1)
-	}
+  spinner = yoctoSpinner({ text: "Finding latest release tag..." }).start()
+  try {
+    releaseData.latestTag = getLatestReleaseTag()
+  } catch (error) {
+    spinner.error(`Failed to get latest release tag: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
 
-	spinner.success(releaseData.latestTag ? `Latest release tag is ${releaseData.latestTag}` : "No release tags found, will use project version")
+  spinner.success(releaseData.latestTag ? `Latest release tag is ${releaseData.latestTag}` : "No release tags found, will use project version")
 
-	// Get commits since latest release tag (and check that there are commits)
-	spinner = yoctoSpinner({ text: releaseData.latestTag ? `Getting git log commits since latest release tag ${releaseData.latestTag}` : "No latest tag found, getting all commits" }).start()
-	try {
-		releaseData.commits = getCommitsSinceTag(releaseData.latestTag)
-		if (releaseData.commits.length === 0) {
-			spinner.error(`No commits found. Why do you want to create a release with no new changes??? 🍕`)
-			process.exit(1)
-		}
-	} catch (error) {
-		spinner.error(`Failed to get commits: ${error instanceof Error ? error.message : String(error)}`)
-		process.exit(1)
-	}
-	spinner.success(`Found ${releaseData.commits.length} commit(s) since latest tag ${releaseData.latestTag}`)
+  // Get commits since latest release tag (and check that there are commits)
+  spinner = yoctoSpinner({ text: releaseData.latestTag ? `Getting git log commits since latest release tag ${releaseData.latestTag}` : "No latest tag found, getting all commits" }).start()
+  try {
+    releaseData.commits = getCommitsSinceTag(releaseData.latestTag)
+    if (releaseData.commits.length === 0) {
+      spinner.error(`No commits found. Why do you want to create a release with no new changes??? 🍕`)
+      process.exit(1)
+    }
+  } catch (error) {
+    spinner.error(`Failed to get commits: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+  spinner.success(`Found ${releaseData.commits.length} commit(s) since latest tag ${releaseData.latestTag}`)
 
-	// Finn ut av hva slags semver type release vi skal lage basert på latestTag og project version
-	spinner = yoctoSpinner({ text: "Determining release type (semver) based on latest release tag and current project version..." }).start()
-	try {
-		releaseData.releaseType = getSemverReleaseType(releaseData.latestTag, releaseData.projectInfo)
-	} catch (error) {
-		spinner.error(`Failed to determine semver type: ${error instanceof Error ? error.message : String(error)}`)
-		process.exit(1)
-	}
-	spinner.success(`Determined release type (semver) is ${releaseData.releaseType}. Release-tag will be ${releaseData.projectInfo.version}`)
+  // Finn ut av hva slags semver type release vi skal lage basert på latestTag og project version
+  spinner = yoctoSpinner({ text: "Determining release type (semver) based on latest release tag and current project version..." }).start()
+  try {
+    releaseData.releaseType = getSemverReleaseType(releaseData.latestTag, releaseData.projectInfo)
+  } catch (error) {
+    spinner.error(`Failed to determine semver type: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+  spinner.success(`Determined release type (semver) is ${releaseData.releaseType}. Release-tag will be ${releaseData.projectInfo.version}`)
 
-	try {
-		releaseData.releaseNotes = generateReleaseNotes(releaseData)
-	} catch (error) {
-		spinner.error(`Failed to generate release notes: ${error instanceof Error ? error.message : String(error)}`)
-		process.exit(1)
-	}
-	spinner.success("Release notes generated")
+  try {
+    releaseData.releaseNotes = generateReleaseNotes(releaseData)
+  } catch (error) {
+    spinner.error(`Failed to generate release notes: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+  spinner.success("Release notes generated")
 
-	// Then we create a PR from a query link to GitHub with the right info filled in
-	const releaseTitle = `Release ${releaseData.projectInfo.version}`
-	const releaseBody: string = releaseData.releaseNotes
+  // Then we create a PR from a query link to GitHub with the right info filled in
+  const releaseTitle = `Release ${releaseData.projectInfo.version}`
+  const releaseBody: string = releaseData.releaseNotes
 
-	const releaseLink = `${repoInfo.githubUrl}/releases/new?tag=${encodeURIComponent(releaseData.projectInfo.version)}&title=${encodeURIComponent(releaseTitle)}&body=${encodeURIComponent(releaseBody)}`
+  const releaseLink = `${repoInfo.githubUrl}/releases/new?tag=${encodeURIComponent(releaseData.projectInfo.version)}&title=${encodeURIComponent(releaseTitle)}&body=${encodeURIComponent(releaseBody)}`
 
-	openUrl(releaseLink, "🚀 Create your release here if it did not open automatically")
+  openUrl(releaseLink, "🚀 Create your release here if it did not open automatically")
 }

--- a/src/types/git.ts
+++ b/src/types/git.ts
@@ -1,27 +1,27 @@
 export type RepoInfo = {
-	remoteUrl: string
-	githubUrl: string
-	githubUsername?: string | undefined
-	currentBranch: string
-	defaultBranch: string
-	repoIsClean: boolean
-	commitDiff: {
-		behind: number
-		ahead: number
-	}
+  remoteUrl: string
+  githubUrl: string
+  githubUsername?: string | undefined
+  currentBranch: string
+  defaultBranch: string
+  repoIsClean: boolean
+  commitDiff: {
+    behind: number
+    ahead: number
+  }
 }
 
 export type GitLogCommit = {
-	hash: string
-	authorName: string
-	authorEmail: string
-	subject: string
-	body: string
-	commitDate: string
+  hash: string
+  authorName: string
+  authorEmail: string
+  subject: string
+  body: string
+  commitDate: string
 }
 
 export type GitCommitType = "major" | "minor" | "patch" | "maintenance" | "other"
 
 export type SortedCommits = {
-	[K in GitCommitType]: GitLogCommit[]
+  [K in GitCommitType]: GitLogCommit[]
 }

--- a/src/types/semver.ts
+++ b/src/types/semver.ts
@@ -1,15 +1,15 @@
 export type ProjectInfo = {
-	version: string
-	type: "node" | "dotnet"
-	paths: string[]
-	name?: string
+  version: string
+  type: "node" | "dotnet"
+  paths: string[]
+  name?: string
 }
 
 export type NextVersion = {
-	version: string
-	isInitialRelease: boolean
-	source: "tag" | "project" | "project-already-bumped" | "vfk-cli"
-	description: string
+  version: string
+  isInitialRelease: boolean
+  source: "tag" | "project" | "project-already-bumped" | "vfk-cli"
+  description: string
 }
 
 export type ReleaseType = "major" | "minor" | "patch" | "initial-release"

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -4,27 +4,27 @@ import type { NextVersion, ProjectInfo, ReleaseType } from "./semver.js"
 export type SupportedSemverType = "major" | "minor" | "patch"
 
 export type PullRequestData = {
-	semverType: SupportedSemverType
-	latestTag: string | null
-	projectInfo: ProjectInfo | null
-	nextVersion: NextVersion | null
-	sortedCommits: SortedCommits | null
+  semverType: SupportedSemverType
+  latestTag: string | null
+  projectInfo: ProjectInfo | null
+  nextVersion: NextVersion | null
+  sortedCommits: SortedCommits | null
 }
 
 export type ReleaseData = {
-	latestTag: string | null
-	projectInfo: ProjectInfo | null
-	releaseType: ReleaseType | null
-	commits: GitLogCommit[] | null
-	releaseNotes: string | null
+  latestTag: string | null
+  projectInfo: ProjectInfo | null
+  releaseType: ReleaseType | null
+  commits: GitLogCommit[] | null
+  releaseNotes: string | null
 }
 
 export type NilsReleaseData = {
-	semverType: SupportedSemverType
-	latestTag: string | null
-	projectInfo: ProjectInfo | null
-	releaseType: ReleaseType | null
-	nextVersion: NextVersion | null
-	commits: GitLogCommit[] | null
-	releaseNotes: string | null
+  semverType: SupportedSemverType
+  latestTag: string | null
+  projectInfo: ProjectInfo | null
+  releaseType: ReleaseType | null
+  nextVersion: NextVersion | null
+  commits: GitLogCommit[] | null
+  releaseNotes: string | null
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,49 +1,49 @@
 {
-	// Visit https://aka.ms/tsconfig to read more about this file
-	"compilerOptions": {
-		// File Layout
-		"rootDir": "./src",
-		"outDir": "./dist",
+  // Visit https://aka.ms/tsconfig to read more about this file
+  "compilerOptions": {
+    // File Layout
+    "rootDir": "./src",
+    "outDir": "./dist",
 
-		// Environment Settings
-		// See also https://aka.ms/tsconfig/module
-		"module": "NodeNext",
-		"target": "ESNext",
-		"lib": ["esnext"],
-		"types": ["node"],
+    // Environment Settings
+    // See also https://aka.ms/tsconfig/module
+    "module": "NodeNext",
+    "target": "ESNext",
+    "lib": ["esnext"],
+    "types": ["node"],
 
-		// Other Outputs
-		"sourceMap": true,
-		"declaration": true,
-		"declarationMap": true,
-		"stripInternal": true,
+    // Other Outputs
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+    "stripInternal": true,
 
-		// Stricter Typechecking Options
-		"noUncheckedIndexedAccess": true,
-		"exactOptionalPropertyTypes": true,
+    // Stricter Typechecking Options
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
 
-		// Style Options
-		"noImplicitReturns": true,
-		"noImplicitOverride": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"noFallthroughCasesInSwitch": true,
-		"noPropertyAccessFromIndexSignature": true,
+    // Style Options
+    "noImplicitReturns": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true,
 
-		// Recommended Options
-		"allowSyntheticDefaultImports": true,
-		"moduleResolution": "nodenext",
-		"strict": true,
-		"alwaysStrict": true,
-		"verbatimModuleSyntax": true,
-		"isolatedModules": true,
-		"noUncheckedSideEffectImports": true,
-		"moduleDetection": "force",
-		"skipLibCheck": true,
-		"forceConsistentCasingInFileNames": true,
+    // Recommended Options
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "nodenext",
+    "strict": true,
+    "alwaysStrict": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noUncheckedSideEffectImports": true,
+    "moduleDetection": "force",
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
 
-		// Modules
-		"resolveJsonModule": true
-	},
-	"exclude": ["node_modules", "dist"]
+    // Modules
+    "resolveJsonModule": true
+  },
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
### Patch commits:
- fix: Use builtin `npm version` when bumping node project version (f5de9c2)

### Maintenance commits:
- chore: Make sure all release types are handled equally in an initial release (d1c0bcb)
- chore: Set biome to use `space` instead of `tab` to have consistent spacing regardless of IDE/client (2c1185d)

Fixes: #33
Fixes: #35